### PR TITLE
Query Conversion

### DIFF
--- a/src/GraphQLToKarate.Application/Program.cs
+++ b/src/GraphQLToKarate.Application/Program.cs
@@ -29,6 +29,13 @@ var graphql = """
       todos: [[Todo!]]!
     }
 
+    type MoreNesting {
+      id: String!
+      name: String!
+      colors: [Color!]!
+      nestedTodos: [NestedTodo!]!
+    }
+
     union TodoUnion = Todo | SimpleTodo
 
     input TodoInputType {
@@ -50,13 +57,21 @@ var graphql = """
           id: String!,
           "A default value of false"
           isCompleted: Boolean=false
-        ): Todo
+        ): Todo!
 
         "Returns a list (or null) that can contain null values"
         todos(
           "Required argument that is a list that cannot contain null values"
           ids: [String!]!
         ): [Todo]
+
+        nestedTodos(
+          ids: [String!]!
+        ): [[NestedTodo]]
+
+        moreNestedTodos(
+          ids: [String!]!
+        ): [[MoreNesting]]
     }
 
     type Mutation {
@@ -79,15 +94,26 @@ var graphql = """
     }
     """;
 
-var converter = new Converter(new GraphQLObjectTypeDefinitionConverter(new GraphQLTypeConverterFactory()));
+var converter = new Converter(
+    new GraphQLObjectTypeDefinitionConverter(new GraphQLTypeConverterFactory()),
+    new GraphQLQueryFieldConverter()
+);
 
-var karateObjects = converter.Convert(graphql);
+var (karateObjects, graphQLQueryFields) = converter.Convert(graphql);
+
+foreach (var graphQLQueryField in graphQLQueryFields)
+{
+    Console.WriteLine($"{graphQLQueryField.Name}: {graphQLQueryField.ReturnTypeName}");
+    Console.WriteLine(graphQLQueryField.QueryString);
+    Console.WriteLine();
+}
 
 foreach (var karateObject in karateObjects)
 {
+    Console.WriteLine(karateObject.Name);
     Console.WriteLine(karateObject);
     Console.WriteLine();
 }
 
-Console.WriteLine("Done! Press any enter to exit...");
+Console.WriteLine("Done! Press enter to exit...");
 Console.ReadLine();

--- a/src/GraphQLToKarate.Library/Converter.cs
+++ b/src/GraphQLToKarate.Library/Converter.cs
@@ -9,40 +9,53 @@ namespace GraphQLToKarate.Library;
 public sealed class Converter
 {
     private readonly IGraphQLObjectTypeDefinitionConverter _graphQLObjectTypeDefinitionConverter;
+    private readonly IGraphQLQueryFieldConverter _graphQLQueryFieldConverter;
 
-    public Converter(IGraphQLObjectTypeDefinitionConverter graphQLObjectTypeDefinitionConverter) =>
+    public Converter(
+        IGraphQLObjectTypeDefinitionConverter graphQLObjectTypeDefinitionConverter,
+        IGraphQLQueryFieldConverter graphQLQueryFieldConverter)
+    {
         _graphQLObjectTypeDefinitionConverter = graphQLObjectTypeDefinitionConverter;
+        _graphQLQueryFieldConverter = graphQLQueryFieldConverter;
+    }
 
-    public IEnumerable<KarateObject> Convert(ROM source)
+    public (IEnumerable<KarateObject> KarateObjects, IEnumerable<GraphQLQueryFieldType> GraphQLQueryFields) Convert(
+        string source)
     {
         var graphQLDocument = Parser.Parse(source);
 
-        var graphQLEnumTypesNames = graphQLDocument.Definitions
+        var graphQLEnumTypeDefinitionsByName = graphQLDocument.Definitions
             .OfType<GraphQLEnumTypeDefinition>()
-            .Select(definition => definition.Name.StringValue)
-            .ToHashSet();
+            .ToDictionary(definition => definition.Name.StringValue);
 
-        var graphQLObjectTypeDefinitions = graphQLDocument.Definitions
+        var graphQLObjectTypeDefinitionsByName = graphQLDocument.Definitions
             .OfType<GraphQLObjectTypeDefinition>()
             .Where(definition => definition.Name.StringValue != GraphQLToken.Query &&
                                  definition.Name.StringValue != GraphQLToken.Mutation)
-            .ToList();
-
-        var graphQLCustomTypeNames = graphQLObjectTypeDefinitions
-            .Select(definition => definition.Name.StringValue)
-            .ToHashSet();
+            .ToDictionary(definition => definition.Name.StringValue);
 
         var graphQLUserDefinedTypes = new GraphQLUserDefinedTypes
         {
-            CustomTypes = graphQLCustomTypeNames,
-            EnumTypes = graphQLEnumTypesNames
+            GraphQLEnumTypeDefinitionsByName = graphQLEnumTypeDefinitionsByName,
+            GraphQLObjectTypeDefinitionsByName = graphQLObjectTypeDefinitionsByName
         };
 
-        return graphQLObjectTypeDefinitions.Select(
+        var karateObjects = graphQLObjectTypeDefinitionsByName.Values.Select(
             graphQLObjectTypeDefinition => _graphQLObjectTypeDefinitionConverter.Convert(
                 graphQLObjectTypeDefinition,
                 graphQLUserDefinedTypes
             )
         );
+
+        var graphQLQueryTypeDefinition = graphQLDocument.Definitions
+            .OfType<GraphQLObjectTypeDefinition>()
+            .FirstOrDefault(definition => definition.Name.StringValue == GraphQLToken.Query);
+
+        var graphQLQueryFieldTypes = graphQLQueryTypeDefinition!.Fields!.Select(
+            graphQLFieldDefinition =>
+                _graphQLQueryFieldConverter.Convert(graphQLFieldDefinition, graphQLUserDefinedTypes)
+        );
+
+        return (karateObjects, graphQLQueryFieldTypes);
     }
 }

--- a/src/GraphQLToKarate.Library/Converters/GraphQLQueryFieldConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLQueryFieldConverter.cs
@@ -63,7 +63,11 @@ public sealed class GraphQLQueryFieldConverter : IGraphQLQueryFieldConverter
 
         stringBuilder.Append(new string(SchemaToken.Space, indentationLevel));
         stringBuilder.Append(SchemaToken.CloseBrace);
-        stringBuilder.Append(Environment.NewLine);
+
+        if (indentationLevel > 0)
+        {
+            stringBuilder.Append(Environment.NewLine);
+        }
 
         return stringBuilder.ToString();
     }

--- a/src/GraphQLToKarate.Library/Converters/GraphQLQueryFieldConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLQueryFieldConverter.cs
@@ -1,0 +1,70 @@
+﻿using GraphQLParser.AST;
+using GraphQLToKarate.Library.Tokens;
+using GraphQLToKarate.Library.Types;
+using System.Text;
+using GraphQLToKarate.Library.Extensions;
+
+namespace GraphQLToKarate.Library.Converters;
+
+public sealed class GraphQLQueryFieldConverter : IGraphQLQueryFieldConverter
+{
+    public GraphQLQueryFieldType Convert(
+        GraphQLFieldDefinition graphQLQueryFieldDefinition,
+        GraphQLUserDefinedTypes graphQLUserDefinedTypes
+    ) => new(graphQLQueryFieldDefinition)
+    {
+        QueryString = ConvertQueryString(graphQLQueryFieldDefinition, graphQLUserDefinedTypes)
+    };
+
+    private static string ConvertQueryString(
+        GraphQLFieldDefinition graphQLQueryFieldDefinition,
+        GraphQLUserDefinedTypes graphQLUserDefinedTypes,
+        int indentationLevel = 0)
+    {
+        var stringBuilder = new StringBuilder();
+
+        stringBuilder.Append(new string(SchemaToken.Space, indentationLevel));
+        stringBuilder.Append(graphQLQueryFieldDefinition.Name.StringValue);
+
+        // TODO: handle field arguments
+
+        stringBuilder.Append(SchemaToken.Space);
+        stringBuilder.Append(SchemaToken.OpenBrace);
+        stringBuilder.Append(Environment.NewLine);
+
+        if (graphQLUserDefinedTypes.GraphQLObjectTypeDefinitionsByName.TryGetValue(
+                graphQLQueryFieldDefinition.Type.GetTypeName(), out var graphQLObjectTypeDefinition))
+        {
+            foreach (var innerGraphQLFieldDefinition in graphQLObjectTypeDefinition.Fields!)
+            {
+                var graphQLTypeName = innerGraphQLFieldDefinition.Type.GetTypeName();
+
+                if (graphQLUserDefinedTypes.GraphQLObjectTypeDefinitionsByName.ContainsKey(graphQLTypeName))
+                {
+                    stringBuilder.Append(
+                        ConvertQueryString(
+                            innerGraphQLFieldDefinition,
+                            graphQLUserDefinedTypes,
+                            indentationLevel + 2
+                        )
+                    );
+                }
+                else
+                {
+                    stringBuilder.Append(new string(SchemaToken.Space, indentationLevel + 2));
+                    stringBuilder.Append(innerGraphQLFieldDefinition.Name.StringValue);
+
+                    // TODO: handle field arguments
+
+                    stringBuilder.Append(Environment.NewLine);
+                }
+            }
+        }
+
+        stringBuilder.Append(new string(SchemaToken.Space, indentationLevel));
+        stringBuilder.Append(SchemaToken.CloseBrace);
+        stringBuilder.Append(Environment.NewLine);
+
+        return stringBuilder.ToString();
+    }
+}

--- a/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverter.cs
@@ -9,8 +9,8 @@ namespace GraphQLToKarate.Library.Converters;
 internal sealed class GraphQLTypeConverter : IGraphQLTypeConverter
 {
     public KarateTypeBase Convert(
-        string graphQLFieldName, 
-        GraphQLType graphQLType, 
+        string graphQLFieldName,
+        GraphQLType graphQLType,
         GraphQLUserDefinedTypes graphQLUserDefinedTypes)
     {
         var karateTypeSchema = (graphQLType as GraphQLNamedType)!.Name.StringValue switch
@@ -20,9 +20,14 @@ internal sealed class GraphQLTypeConverter : IGraphQLTypeConverter
             GraphQLToken.Int => KarateToken.Number,
             GraphQLToken.Float => KarateToken.Number,
             GraphQLToken.Boolean => KarateToken.Boolean,
-            { } graphQLTypeName when graphQLUserDefinedTypes.EnumTypes.Contains(graphQLTypeName) => KarateToken.String,
-            { } graphQLTypeName when graphQLUserDefinedTypes.CustomTypes.Contains(graphQLTypeName) => $"{graphQLTypeName.FirstCharToLower()}Schema",
-            _ => throw new ArgumentException($"Unknown GraphQL type name for GraphQL field {graphQLFieldName}!", nameof(graphQLType))
+            { } graphQLTypeName when graphQLUserDefinedTypes.GraphQLEnumTypeDefinitionNames
+                .Contains(graphQLTypeName) => KarateToken.String,
+            { } graphQLTypeName when graphQLUserDefinedTypes.GraphQLObjectTypeDefinitionNames
+                .Contains(graphQLTypeName) => $"{graphQLTypeName.FirstCharToLower()}Schema",
+            _ => throw new ArgumentException(
+                $"Unknown GraphQL type name for GraphQL field {graphQLFieldName}!",
+                nameof(graphQLType)
+            )
         };
 
         return new KarateType(karateTypeSchema, graphQLFieldName);

--- a/src/GraphQLToKarate.Library/Converters/IGraphQLQueryFieldConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/IGraphQLQueryFieldConverter.cs
@@ -1,0 +1,23 @@
+﻿using GraphQLParser.AST;
+using GraphQLToKarate.Library.Types;
+
+namespace GraphQLToKarate.Library.Converters;
+
+/// <summary>
+///     Converts <see cref="GraphQLFieldDefinition"/> instances for GraphQL queries to <see cref="GraphQLQueryFieldType"/> instances.
+/// </summary>
+public interface IGraphQLQueryFieldConverter
+{
+    /// <summary>
+    ///     Convert the given <see cref="GraphQLFieldDefinition"/> of a GraphQL query to a <see cref="GraphQLQueryFieldType"/>.
+    /// </summary>
+    /// <param name="graphQLQueryFieldDefinition">The query field to convert.</param>
+    /// <param name="graphQLUserDefinedTypes">
+    ///     The other user-defined GraphQL types, used for handling nested types, enums, input types, etc.
+    /// </param>
+    /// <returns>The converted <see cref="GraphQLQueryFieldType"/>.</returns>
+    GraphQLQueryFieldType Convert(
+        GraphQLFieldDefinition graphQLQueryFieldDefinition,
+        GraphQLUserDefinedTypes graphQLUserDefinedTypes
+    );
+}

--- a/src/GraphQLToKarate.Library/Converters/IGraphQLTypeConverterFactory.cs
+++ b/src/GraphQLToKarate.Library/Converters/IGraphQLTypeConverterFactory.cs
@@ -1,17 +1,10 @@
-﻿using GraphQLToKarate.Library.Types;
-
-namespace GraphQLToKarate.Library.Converters;
+﻿namespace GraphQLToKarate.Library.Converters;
 
 /// <summary>
 ///     Used to create various <see cref="IGraphQLTypeConverter"/> implementations.
 /// </summary>
 public interface IGraphQLTypeConverterFactory
 {
-    /// <summary>
-    ///     Create the base <see cref="IGraphQLTypeConverter"/> which will convert to
-    ///     a <see 
-    /// </summary>
-    /// <returns></returns>
     IGraphQLTypeConverter CreateGraphQLTypeConverter();
 
     IGraphQLTypeConverter CreateGraphQLListTypeConverter();

--- a/src/GraphQLToKarate.Library/Extensions/GraphQLTypeExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/GraphQLTypeExtensions.cs
@@ -1,0 +1,27 @@
+﻿using GraphQLParser.AST;
+using GraphQLToKarate.Library.Exceptions;
+
+namespace GraphQLToKarate.Library.Extensions;
+
+internal static class GraphQLTypeExtensions
+{
+    public static string GetTypeName(this GraphQLType graphQLType)
+    {
+        while (true)
+        {
+            switch (graphQLType)
+            {
+                case GraphQLNonNullType graphQLNonNullType:
+                    graphQLType = graphQLNonNullType.Type;
+                    continue;
+                case GraphQLListType graphQLListType:
+                    graphQLType = graphQLListType.Type;
+                    continue;
+                case GraphQLNamedType namedType:
+                    return namedType.Name.StringValue;
+            }
+
+            throw new InvalidGraphQLTypeException();
+        }
+    }
+}

--- a/src/GraphQLToKarate.Library/Tokens/SchemaToken.cs
+++ b/src/GraphQLToKarate.Library/Tokens/SchemaToken.cs
@@ -9,6 +9,8 @@ internal static class SchemaToken
     
     public const char CloseBrace = '}';
 
+    public const char Space = ' ';
+
     public const char Comma = ',';
 
     public const string Indent = "  ";

--- a/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
+++ b/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
@@ -1,0 +1,22 @@
+﻿using GraphQLParser.AST;
+using GraphQLToKarate.Library.Extensions;
+
+namespace GraphQLToKarate.Library.Types;
+
+public sealed class GraphQLQueryFieldType
+{
+    private readonly GraphQLFieldDefinition _queryField;
+
+    public string Name => _queryField.Name.StringValue;
+
+    public string ReturnTypeName => _queryField.Type.GetTypeName();
+
+    public ASTNodeKind ReturnTypeKind => _queryField.Kind;
+
+    public required string QueryString { get; init; }
+
+    public GraphQLQueryFieldType(GraphQLFieldDefinition queryField)
+    {
+        _queryField = queryField;
+    }
+}

--- a/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
+++ b/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
@@ -11,8 +11,6 @@ public sealed class GraphQLQueryFieldType
 
     public string ReturnTypeName => _queryField.Type.GetTypeName();
 
-    public ASTNodeKind ReturnTypeKind => _queryField.Kind;
-
     public required string QueryString { get; init; }
 
     public GraphQLQueryFieldType(GraphQLFieldDefinition queryField)

--- a/src/GraphQLToKarate.Library/Types/GraphQLUserDefinedTypes.cs
+++ b/src/GraphQLToKarate.Library/Types/GraphQLUserDefinedTypes.cs
@@ -11,11 +11,7 @@ public sealed class GraphQLUserDefinedTypes
 
     public ICollection<string> GraphQLObjectTypeDefinitionNames => GraphQLObjectTypeDefinitionsByName.Keys;
 
-    public ICollection<GraphQLObjectTypeDefinition> GraphQLObjectTypeDefinitions => GraphQLObjectTypeDefinitionsByName.Values;
-
     public required IDictionary<string, GraphQLEnumTypeDefinition> GraphQLEnumTypeDefinitionsByName { get; init; } = new Dictionary<string, GraphQLEnumTypeDefinition>();
 
     public ICollection<string> GraphQLEnumTypeDefinitionNames => GraphQLEnumTypeDefinitionsByName.Keys;
-
-    public ICollection<GraphQLEnumTypeDefinition> GraphQLEnumTypeDefinitions => GraphQLEnumTypeDefinitionsByName.Values;
 }

--- a/src/GraphQLToKarate.Library/Types/GraphQLUserDefinedTypes.cs
+++ b/src/GraphQLToKarate.Library/Types/GraphQLUserDefinedTypes.cs
@@ -1,17 +1,21 @@
-﻿namespace GraphQLToKarate.Library.Types;
+﻿using GraphQLParser.AST;
+
+namespace GraphQLToKarate.Library.Types;
 
 /// <summary>
 ///     Represents the custom user-defined types, enums, etc. within the GraphQL schema.
 /// </summary>
 public sealed class GraphQLUserDefinedTypes
 {
-    /// <summary>
-    ///     A set of user-defined, custom GraphQL type names.
-    /// </summary>
-    public ISet<string> CustomTypes { get; init; } = new HashSet<string>();
+    public required IDictionary<string, GraphQLObjectTypeDefinition> GraphQLObjectTypeDefinitionsByName { get; init; } = new Dictionary<string, GraphQLObjectTypeDefinition>();
 
-    /// <summary>
-    ///     A set of user-defined, custom GraphQL enum names.
-    /// </summary>
-    public ISet<string> EnumTypes { get; init; } = new HashSet<string>();
+    public ICollection<string> GraphQLObjectTypeDefinitionNames => GraphQLObjectTypeDefinitionsByName.Keys;
+
+    public ICollection<GraphQLObjectTypeDefinition> GraphQLObjectTypeDefinitions => GraphQLObjectTypeDefinitionsByName.Values;
+
+    public required IDictionary<string, GraphQLEnumTypeDefinition> GraphQLEnumTypeDefinitionsByName { get; init; } = new Dictionary<string, GraphQLEnumTypeDefinition>();
+
+    public ICollection<string> GraphQLEnumTypeDefinitionNames => GraphQLEnumTypeDefinitionsByName.Keys;
+
+    public ICollection<GraphQLEnumTypeDefinition> GraphQLEnumTypeDefinitions => GraphQLEnumTypeDefinitionsByName.Values;
 }

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLListTypeConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLListTypeConverterTests.cs
@@ -46,6 +46,12 @@ internal sealed class GraphQLListTypeConverterTests
         {
             const string testFieldName = "Test";
 
+            var emptyGraphQLUserDefinedTypes = new GraphQLUserDefinedTypes
+            {
+                GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>(),
+                GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>()
+            };
+
             yield return new TestCaseData(
                 testFieldName,
                 new GraphQLListType
@@ -55,7 +61,7 @@ internal sealed class GraphQLListTypeConverterTests
                         Name = new GraphQLName(GraphQLToken.Boolean)
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateListType(
                     new KarateNullType(
                         new KarateType(KarateToken.Boolean, testFieldName)
@@ -72,7 +78,7 @@ internal sealed class GraphQLListTypeConverterTests
                         Name = new GraphQLName(GraphQLToken.Float)
                     },
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateListType(
                     new KarateNullType(
                         new KarateType(KarateToken.Number, testFieldName)
@@ -90,7 +96,7 @@ internal sealed class GraphQLListTypeConverterTests
                         Name = new GraphQLName(GraphQLToken.Int)
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateListType(
                     new KarateNullType(
                         new KarateType(KarateToken.Number, testFieldName)
@@ -108,7 +114,7 @@ internal sealed class GraphQLListTypeConverterTests
                         Name = new GraphQLName(GraphQLToken.String)
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateListType(
                     new KarateNullType(
                         new KarateType(KarateToken.String, testFieldName)
@@ -125,7 +131,7 @@ internal sealed class GraphQLListTypeConverterTests
                         Name = new GraphQLName(GraphQLToken.Id)
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateListType(
                     new KarateNullType(
                         new KarateType(KarateToken.String, testFieldName)
@@ -146,7 +152,11 @@ internal sealed class GraphQLListTypeConverterTests
                 },
                 new GraphQLUserDefinedTypes
                 {
-                    EnumTypes = new HashSet<string> { enumTypeName }
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        { enumTypeName, new GraphQLEnumTypeDefinition() }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>()
                 },
                 new KarateListType(
                     new KarateNullType(
@@ -168,8 +178,14 @@ internal sealed class GraphQLListTypeConverterTests
                 },
                 new GraphQLUserDefinedTypes
                 {
-                    EnumTypes = new HashSet<string> { enumTypeName },
-                    CustomTypes = new HashSet<string> { customTypeName }
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        { enumTypeName, new GraphQLEnumTypeDefinition() }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
+                    {
+                        { customTypeName, new GraphQLObjectTypeDefinition() }
+                    }
                 },
                 new KarateListType(
                     new KarateNullType(
@@ -190,7 +206,7 @@ internal sealed class GraphQLListTypeConverterTests
                         }
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateListType(
                     new KarateNonNullType(
                         new KarateType(KarateToken.Boolean, testFieldName)
@@ -210,7 +226,7 @@ internal sealed class GraphQLListTypeConverterTests
                         }
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateListType(
                     new KarateNonNullType(
                         new KarateType(KarateToken.Number, testFieldName)
@@ -230,7 +246,8 @@ internal sealed class GraphQLListTypeConverterTests
                             Name = new GraphQLName(GraphQLToken.Int)
                         }
                     }
-                }, new GraphQLUserDefinedTypes(),
+                }, 
+                emptyGraphQLUserDefinedTypes,
                 new KarateListType(
                     new KarateNonNullType(
                         new KarateType(KarateToken.Number, testFieldName)
@@ -251,7 +268,7 @@ internal sealed class GraphQLListTypeConverterTests
                         }
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateListType(
                     new KarateNonNullType(
                         new KarateType(KarateToken.String, testFieldName)
@@ -271,7 +288,7 @@ internal sealed class GraphQLListTypeConverterTests
                         }
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateListType(
                     new KarateNonNullType(
                         new KarateType(KarateToken.String, testFieldName)
@@ -293,7 +310,11 @@ internal sealed class GraphQLListTypeConverterTests
                 },
                 new GraphQLUserDefinedTypes
                 {
-                    EnumTypes = new HashSet<string> { enumTypeName }
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        { enumTypeName, new GraphQLEnumTypeDefinition() }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>()
                 },
                 new KarateListType(
                     new KarateNonNullType(
@@ -316,8 +337,14 @@ internal sealed class GraphQLListTypeConverterTests
                 },
                 new GraphQLUserDefinedTypes
                 {
-                    EnumTypes = new HashSet<string> { enumTypeName },
-                    CustomTypes = new HashSet<string> { customTypeName }
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        { enumTypeName, new GraphQLEnumTypeDefinition() }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
+                    {
+                        { customTypeName, new GraphQLObjectTypeDefinition() }
+                    }
                 },
                 new KarateListType(
                     new KarateNonNullType(
@@ -341,7 +368,7 @@ internal sealed class GraphQLListTypeConverterTests
                         }
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateListType(
                     new KarateNullType(
                         new KarateListType(

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLNonNullTypeConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLNonNullTypeConverterTests.cs
@@ -46,6 +46,12 @@ internal sealed class GraphQLNonNullTypeConverterTests
         {
             const string testFieldName = "Test";
 
+            var emptyGraphQLUserDefinedTypes = new GraphQLUserDefinedTypes
+            {
+                GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>(),
+                GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>()
+            };
+
             yield return new TestCaseData(
                 testFieldName,
                 new GraphQLNonNullType
@@ -55,7 +61,7 @@ internal sealed class GraphQLNonNullTypeConverterTests
                         Name = new GraphQLName(GraphQLToken.Boolean)
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNonNullType(new KarateType(KarateToken.Boolean, testFieldName))
             ).SetName("Non-nullable Boolean GraphQL type is converted to non-nullable boolean Karate type.");
 
@@ -68,7 +74,7 @@ internal sealed class GraphQLNonNullTypeConverterTests
                         Name = new GraphQLName(GraphQLToken.Float)
                     },
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNonNullType(new KarateType(KarateToken.Number, testFieldName))
             ).SetName("Non-nullable Float GraphQL type is converted to non-nullable number Karate type.");
 
@@ -81,7 +87,7 @@ internal sealed class GraphQLNonNullTypeConverterTests
                         Name = new GraphQLName(GraphQLToken.Int)
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNonNullType(new KarateType(KarateToken.Number, testFieldName))
             ).SetName("Non-nullable Int GraphQL type is converted to non-nullable number Karate type.");
 
@@ -94,7 +100,7 @@ internal sealed class GraphQLNonNullTypeConverterTests
                         Name = new GraphQLName(GraphQLToken.String)
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNonNullType(new KarateType(KarateToken.String, testFieldName))
             ).SetName("Non-nullable String GraphQL type is converted to non-nullable string Karate type.");
 
@@ -107,7 +113,7 @@ internal sealed class GraphQLNonNullTypeConverterTests
                         Name = new GraphQLName(GraphQLToken.Id)
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNonNullType(new KarateType(KarateToken.String, testFieldName))
             ).SetName("Non-nullable ID GraphQL type is converted to non-nullable string Karate type.");
 
@@ -124,7 +130,11 @@ internal sealed class GraphQLNonNullTypeConverterTests
                 },
                 new GraphQLUserDefinedTypes
                 {
-                    EnumTypes = new HashSet<string> { enumTypeName }
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        { enumTypeName, new GraphQLEnumTypeDefinition() }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>()
                 },
                 new KarateNonNullType(new KarateType(KarateToken.String, testFieldName))
             ).SetName("Non-nullable enum GraphQL type is converted to non-nullable string Karate type.");
@@ -142,8 +152,14 @@ internal sealed class GraphQLNonNullTypeConverterTests
                 },
                 new GraphQLUserDefinedTypes
                 {
-                    EnumTypes = new HashSet<string> { enumTypeName },
-                    CustomTypes = new HashSet<string> { customTypeName }
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        { enumTypeName, new GraphQLEnumTypeDefinition() }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
+                    {
+                        { customTypeName, new GraphQLObjectTypeDefinition() }
+                    }
                 },
                 new KarateNonNullType(
                     new KarateType(
@@ -165,7 +181,7 @@ internal sealed class GraphQLNonNullTypeConverterTests
                         }
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNonNullType(
                     new KarateListType(
                         new KarateNullType(

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLNullTypeConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLNullTypeConverterTests.cs
@@ -45,13 +45,19 @@ internal sealed class GraphQLNullTypeConverterTests
         {
             const string testFieldName = "Test";
 
+            var emptyGraphQLUserDefinedTypes = new GraphQLUserDefinedTypes
+            {
+                GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>(),
+                GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>()
+            };
+
             yield return new TestCaseData(
                 testFieldName,
                 new GraphQLNamedType
                 {
                     Name = new GraphQLName(GraphQLToken.Boolean)
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNullType(new KarateType(KarateToken.Boolean, testFieldName))
             ).SetName("Nullable Boolean GraphQL type is converted to nullable boolean Karate type.");
 
@@ -61,7 +67,7 @@ internal sealed class GraphQLNullTypeConverterTests
                 {
                     Name = new GraphQLName(GraphQLToken.Float)
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNullType(new KarateType(KarateToken.Number, testFieldName))
             ).SetName("Nullable Float GraphQL type is converted to nullable number Karate type.");
 
@@ -72,7 +78,7 @@ internal sealed class GraphQLNullTypeConverterTests
                 {
                     Name = new GraphQLName(GraphQLToken.Int)
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNullType(new KarateType(KarateToken.Number, testFieldName))
             ).SetName("Nullable Int GraphQL type is converted to nullable number Karate type.");
 
@@ -82,7 +88,7 @@ internal sealed class GraphQLNullTypeConverterTests
                 {
                     Name = new GraphQLName(GraphQLToken.String)
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNullType(new KarateType(KarateToken.String, testFieldName))
             ).SetName("Nullable String GraphQL type is converted to nullable string Karate type.");
 
@@ -92,7 +98,7 @@ internal sealed class GraphQLNullTypeConverterTests
                 {
                     Name = new GraphQLName(GraphQLToken.Id)
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNullType(new KarateType(KarateToken.String, testFieldName))
             ).SetName("Nullable ID GraphQL type is converted to nullable string Karate type.");
 
@@ -106,7 +112,11 @@ internal sealed class GraphQLNullTypeConverterTests
                 },
                 new GraphQLUserDefinedTypes
                 {
-                    EnumTypes = new HashSet<string> { enumTypeName }
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        { enumTypeName, new GraphQLEnumTypeDefinition() }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>()
                 },
                 new KarateNullType(new KarateType(KarateToken.String, testFieldName))
             ).SetName("Nullable enum GraphQL type is converted to nullable string Karate type.");
@@ -121,8 +131,14 @@ internal sealed class GraphQLNullTypeConverterTests
                 },
                 new GraphQLUserDefinedTypes
                 {
-                    EnumTypes = new HashSet<string> { enumTypeName },
-                    CustomTypes = new HashSet<string> { customTypeName }
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        { enumTypeName, new GraphQLEnumTypeDefinition() }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
+                    {
+                        { customTypeName, new GraphQLObjectTypeDefinition() }
+                    }
                 },
                 new KarateNullType(new KarateType($"{customTypeName.FirstCharToLower()}Schema", testFieldName))
             ).SetName("Nullable custom GraphQL type is converted to nullable custom Karate type.");
@@ -136,7 +152,7 @@ internal sealed class GraphQLNullTypeConverterTests
                         Name = new GraphQLName(GraphQLToken.Boolean)
                     }
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateNullType(
                     new KarateListType(
                         new KarateNullType(

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLQueryFieldConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLQueryFieldConverterTests.cs
@@ -1,0 +1,251 @@
+﻿using FluentAssertions;
+using GraphQLParser.AST;
+using GraphQLToKarate.Library.Converters;
+using GraphQLToKarate.Library.Types;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.Tests.Converters;
+
+[TestFixture]
+internal sealed class GraphQLQueryFieldConverterTests
+{
+    private IGraphQLQueryFieldConverter? _subjectUnderTest;
+
+    [SetUp]
+    public void SetUp() => _subjectUnderTest = new GraphQLQueryFieldConverter();
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void Convert(
+        GraphQLFieldDefinition graphQLQueryFieldDefinition,
+        GraphQLUserDefinedTypes graphQLUeDefinedTypes,
+        GraphQLQueryFieldType expectedGraphQLQueryFieldType)
+    {
+        // act
+        var graphQLQueryFieldType = _subjectUnderTest!.Convert(
+            graphQLQueryFieldDefinition,
+            graphQLUeDefinedTypes
+        );
+
+        // assert
+        graphQLQueryFieldType
+            .Should()
+            .BeEquivalentTo(expectedGraphQLQueryFieldType);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var testGraphQLFieldDefinition = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("person"),
+                Type = new GraphQLNamedType
+                {
+                    Name = new GraphQLName("Person")
+                }
+            };
+
+            var testGraphQLObjectDefinition = new GraphQLObjectTypeDefinition
+            {
+                Name = new GraphQLName("Person"),
+                Fields = new GraphQLFieldsDefinition
+                {
+                    Items = new List<GraphQLFieldDefinition>
+                    {
+                        new()
+                        {
+                            Name = new GraphQLName("id"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("String")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("name"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("String")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("favorite_number"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("Integer")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("favorite_color"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("Color")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var testGraphQLObjectDefinitionWithNesting = new GraphQLObjectTypeDefinition
+            {
+                Name = new GraphQLName("PersonWithFriends"),
+                Fields = new GraphQLFieldsDefinition
+                {
+                    Items = new List<GraphQLFieldDefinition>
+                    {
+                        new()
+                        {
+                            Name = new GraphQLName("id"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("String")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("name"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("String")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("friends"),
+                            Type = new GraphQLListType
+                            {
+                                Type = new GraphQLNamedType
+                                {
+                                    Name = new GraphQLName("Person")
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var testGraphQLEnumTypeDefinition = new GraphQLEnumTypeDefinition()
+            {
+                Name = new GraphQLName("Color"),
+                Values = new GraphQLEnumValuesDefinition
+                {
+                    Items = new List<GraphQLEnumValueDefinition>
+                    {
+                        new()
+                        {
+                            Name = new GraphQLName("RED"),
+                            EnumValue = new GraphQLEnumValue
+                            {
+                                Name = new GraphQLName("RED")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("BLUE"),
+                            EnumValue = new GraphQLEnumValue
+                            {
+                                Name = new GraphQLName("BLUE")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("GREEN"),
+                            EnumValue = new GraphQLEnumValue
+                            {
+                                Name = new GraphQLName("GREEN")
+                            }
+                        }
+                    }
+                }
+            };
+
+            yield return new TestCaseData(
+                testGraphQLFieldDefinition,
+                new GraphQLUserDefinedTypes
+                {
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        {
+                            testGraphQLEnumTypeDefinition.Name.StringValue, 
+                            testGraphQLEnumTypeDefinition
+                        }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
+                    {
+                        {
+                            testGraphQLObjectDefinition.Name.StringValue, 
+                            testGraphQLObjectDefinition
+                        },
+                        {
+                            testGraphQLObjectDefinitionWithNesting.Name.StringValue,
+                            testGraphQLObjectDefinitionWithNesting
+                        }
+                    }
+                },
+                new GraphQLQueryFieldType(testGraphQLFieldDefinition)
+                {
+                    QueryString = """
+                                person {
+                                  id
+                                  name
+                                  favorite_number
+                                  favorite_color
+                                }
+                                """
+                }
+            ).SetName("Converter is able to convert simple query.");
+
+            var testNestedGraphQLFieldDefinition = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("person_with_friends"),
+                Type = new GraphQLNamedType
+                {
+                    Name = new GraphQLName("PersonWithFriends")
+                }
+            };
+
+            yield return new TestCaseData(
+                testNestedGraphQLFieldDefinition,
+                new GraphQLUserDefinedTypes
+                {
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        {
+                            testGraphQLEnumTypeDefinition.Name.StringValue,
+                            testGraphQLEnumTypeDefinition
+                        }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
+                    {
+                        {
+                            testGraphQLObjectDefinition.Name.StringValue,
+                            testGraphQLObjectDefinition
+                        },
+                        {
+                            testGraphQLObjectDefinitionWithNesting.Name.StringValue,
+                            testGraphQLObjectDefinitionWithNesting
+                        }
+                    }
+                },
+                new GraphQLQueryFieldType(testNestedGraphQLFieldDefinition)
+                {
+                    QueryString = """
+                                person_with_friends {
+                                  id
+                                  name
+                                  friends {
+                                    id
+                                    name
+                                    favorite_number
+                                    favorite_color
+                                  }
+                                }
+                                """
+                }
+            ).SetName("Converter is able to convert nested query.");
+        }
+    }
+}

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLTypeConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLTypeConverterTests.cs
@@ -41,13 +41,19 @@ internal sealed class GraphQLTypeConverterTests
         {
             const string testFieldName = "Test";
 
+            var emptyGraphQLUserDefinedTypes = new GraphQLUserDefinedTypes
+            {
+                GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>(),
+                GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>()
+            };
+
             yield return new TestCaseData(
                 testFieldName,
                 new GraphQLNamedType
                 {
                     Name = new GraphQLName(GraphQLToken.Boolean)
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateType(KarateToken.Boolean, testFieldName)
             ).SetName("Boolean GraphQL type is converted to boolean Karate type.");
 
@@ -57,7 +63,7 @@ internal sealed class GraphQLTypeConverterTests
                 {
                     Name = new GraphQLName(GraphQLToken.Float)
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateType(KarateToken.Number, testFieldName)
             ).SetName("Float GraphQL type is converted to number Karate type.");
 
@@ -67,7 +73,7 @@ internal sealed class GraphQLTypeConverterTests
                 {
                     Name = new GraphQLName(GraphQLToken.Int)
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateType(KarateToken.Number, testFieldName)
             ).SetName("Int GraphQL type is converted to number Karate type.");
 
@@ -77,7 +83,7 @@ internal sealed class GraphQLTypeConverterTests
                 {
                     Name = new GraphQLName(GraphQLToken.String)
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateType(KarateToken.String, testFieldName)
             ).SetName("String GraphQL type is converted to string Karate type.");
 
@@ -88,7 +94,7 @@ internal sealed class GraphQLTypeConverterTests
                 {
                     Name = new GraphQLName(GraphQLToken.Id)
                 },
-                new GraphQLUserDefinedTypes(),
+                emptyGraphQLUserDefinedTypes,
                 new KarateType(KarateToken.String, testFieldName)
             ).SetName("ID GraphQL type is converted to string Karate type.");
 
@@ -102,7 +108,11 @@ internal sealed class GraphQLTypeConverterTests
                 },
                 new GraphQLUserDefinedTypes
                 {
-                    EnumTypes = new HashSet<string> { enumTypeName }
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        { enumTypeName, new GraphQLEnumTypeDefinition() }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>()
                 },
                 new KarateType(KarateToken.String, testFieldName)
             ).SetName("Enum GraphQL type is converted to string Karate type.");
@@ -117,8 +127,14 @@ internal sealed class GraphQLTypeConverterTests
                 },
                 new GraphQLUserDefinedTypes
                 {
-                    EnumTypes = new HashSet<string> { enumTypeName },
-                    CustomTypes = new HashSet<string> { customTypeName }
+                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
+                    {
+                        { enumTypeName, new GraphQLEnumTypeDefinition() }
+                    },
+                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
+                    {
+                        { customTypeName, new GraphQLObjectTypeDefinition() }
+                    }
                 },
                 new KarateType($"{customTypeName.FirstCharToLower()}Schema", testFieldName)
             ).SetName("Custom GraphQL type is converted to custom Karate type.");


### PR DESCRIPTION
## Description

- Updated `GraphQLUserDefinedTypes` to be a richer type, able to hold more information which is needed for query conversion
- Functionality to convert GraphQL query fields to a new `GraphQLQueryFieldType` which contains the query field name, materialized query string, return type, and return kind (nullable vs non-nullable vs list).
- Updated temp console app, playing around with nested types

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
