### PR TITLE
Handle Scalar Fields With Arguments

### DIFF
--- a/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
@@ -21,7 +21,7 @@ public class GraphQLInputValueDefinitionConverter : IGraphQLInputValueDefinition
         return graphQLVariableTypeName;
     }
 
-    public ICollection<GraphQLArgumentTypeBase> GetConverted() => _graphQLVariableTypes;
+    public ICollection<GraphQLArgumentTypeBase> GetAllConverted() => _graphQLVariableTypes;
 
     private static GraphQLArgumentTypeBase Convert(
         GraphQLInputValueDefinition graphQLInputValueDefinition,

--- a/src/GraphQLToKarate.Library/Converters/IGraphQLInputValueDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/IGraphQLInputValueDefinitionConverter.cs
@@ -7,5 +7,5 @@ public interface IGraphQLInputValueDefinitionConverter
 {
     GraphQLArgumentTypeBase Convert(GraphQLInputValueDefinition graphQLInputValueDefinition);
 
-    ICollection<GraphQLArgumentTypeBase> GetConverted();
+    ICollection<GraphQLArgumentTypeBase> GetAllConverted();
 }

--- a/src/GraphQLToKarate.Library/Extensions/StringBuilderExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/StringBuilderExtensions.cs
@@ -1,0 +1,8 @@
+﻿using System.Text;
+
+namespace GraphQLToKarate.Library.Extensions;
+
+internal static class StringBuilderExtensions
+{
+    public static void TrimEnd(this StringBuilder source, int length) => source.Remove(source.Length - length, length);
+}

--- a/src/GraphQLToKarate.Library/Types/KarateObject.cs
+++ b/src/GraphQLToKarate.Library/Types/KarateObject.cs
@@ -26,22 +26,22 @@ public sealed class KarateObject
 
     private string GenerateSchemaString()
     {
-        var builder = new StringBuilder();
+        var stringBuilder = new StringBuilder();
 
-        builder.Append(SchemaToken.OpenBrace);
+        stringBuilder.Append(SchemaToken.OpenBrace);
 
         foreach (var karateType in _karateTypes)
         {
-            builder.Append(Environment.NewLine);
-            builder.Append(SchemaToken.Indent);
-            builder.Append($"{karateType.Name}: '{karateType.Schema}'");
-            builder.Append(SchemaToken.Comma);
+            stringBuilder.Append(Environment.NewLine);
+            stringBuilder.Append(SchemaToken.Indent);
+            stringBuilder.Append($"{karateType.Name}: '{karateType.Schema}'");
+            stringBuilder.Append(SchemaToken.Comma);
         }
 
-        builder.Remove(builder.Length - 1, 1);
-        builder.Append(Environment.NewLine);
-        builder.Append(SchemaToken.CloseBrace);
+        stringBuilder.Remove(stringBuilder.Length - 1, 1);
+        stringBuilder.Append(Environment.NewLine);
+        stringBuilder.Append(SchemaToken.CloseBrace);
 
-        return builder.ToString();
+        return stringBuilder.ToString();
     }
 }

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLQueryFieldConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLQueryFieldConverterTests.cs
@@ -127,6 +127,135 @@ internal sealed class GraphQLQueryFieldConverterTests
                 }
             };
 
+            var testGraphQLObjectDefinitionWithNestedFieldArguments = new GraphQLObjectTypeDefinition
+            {
+                Name = new GraphQLName("PersonWithFriendsWithArguments"),
+                Fields = new GraphQLFieldsDefinition
+                {
+                    Items = new List<GraphQLFieldDefinition>
+                    {
+                        new()
+                        {
+                            Name = new GraphQLName("id"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("String")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("name"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("String")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("friends"),
+                            Type = new GraphQLListType
+                            {
+                                Type = new GraphQLNamedType
+                                {
+                                    Name = new GraphQLName("Person")
+                                }
+                            },
+                            Arguments = new GraphQLArgumentsDefinition
+                            {
+                                Items = new List<GraphQLInputValueDefinition>
+                                {
+                                    new()
+                                    {
+                                        Name = new GraphQLName("ids"),
+                                        Type = new GraphQLListType
+                                        {
+                                            Type = new GraphQLNamedType
+                                            {
+                                                Name = new GraphQLName("String")
+                                            }
+                                        }
+                                    },
+                                    new()
+                                    {
+                                        Name = new GraphQLName("location"),
+                                        Type = new GraphQLNonNullType
+                                        {
+                                            Type = new GraphQLNamedType
+                                            {
+                                                Name = new GraphQLName("String")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var testGraphQLObjectDefinitionWithScalarFieldArguments = new GraphQLObjectTypeDefinition
+            {
+                Name = new GraphQLName("PersonWithFavoriteColors"),
+                Fields = new GraphQLFieldsDefinition
+                {
+                    Items = new List<GraphQLFieldDefinition>
+                    {
+                        new()
+                        {
+                            Name = new GraphQLName("id"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("String")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("name"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("String")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("favoriteNumber"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("Integer")
+                            }
+                        },
+                        new()
+                        {
+                            Name = new GraphQLName("favoriteColors"),
+                            Type = new GraphQLListType
+                            {
+                                Type = new GraphQLNamedType
+                                {
+                                    Name = new GraphQLName("Color")
+                                }
+                            },
+                            Arguments = new GraphQLArgumentsDefinition
+                            {
+                                Items = new List<GraphQLInputValueDefinition>
+                                {
+                                    new()
+                                    {
+                                        Name = new GraphQLName("filter"),
+                                        Type = new GraphQLListType
+                                        {
+                                            Type = new GraphQLNamedType
+                                            {
+                                                Name = new GraphQLName("String")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
             var testGraphQLEnumTypeDefinition = new GraphQLEnumTypeDefinition()
             {
                 Name = new GraphQLName("Color"),
@@ -162,29 +291,39 @@ internal sealed class GraphQLQueryFieldConverterTests
                 }
             };
 
-            yield return new TestCaseData(
-                testGraphQLFieldDefinition,
-                new GraphQLUserDefinedTypes
+            var testGraphQLUserDefinedTypes = new GraphQLUserDefinedTypes
+            {
+                GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
                 {
-                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
                     {
-                        {
-                            testGraphQLEnumTypeDefinition.Name.StringValue, 
-                            testGraphQLEnumTypeDefinition
-                        }
-                    },
-                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
-                    {
-                        {
-                            testGraphQLObjectDefinition.Name.StringValue, 
-                            testGraphQLObjectDefinition
-                        },
-                        {
-                            testGraphQLObjectDefinitionWithNesting.Name.StringValue,
-                            testGraphQLObjectDefinitionWithNesting
-                        }
+                        testGraphQLEnumTypeDefinition.Name.StringValue,
+                        testGraphQLEnumTypeDefinition
                     }
                 },
+                GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
+                {
+                    {
+                        testGraphQLObjectDefinition.Name.StringValue,
+                        testGraphQLObjectDefinition
+                    },
+                    {
+                        testGraphQLObjectDefinitionWithNestedFieldArguments.Name.StringValue,
+                        testGraphQLObjectDefinitionWithNestedFieldArguments
+                    },
+                    {
+                        testGraphQLObjectDefinitionWithNesting.Name.StringValue,
+                        testGraphQLObjectDefinitionWithNesting
+                    },
+                    {
+                        testGraphQLObjectDefinitionWithScalarFieldArguments.Name.StringValue,
+                        testGraphQLObjectDefinitionWithScalarFieldArguments
+                    }
+                }
+            };
+
+            yield return new TestCaseData(
+                testGraphQLFieldDefinition,
+                testGraphQLUserDefinedTypes,
                 new GraphQLQueryFieldType(testGraphQLFieldDefinition)
                 {
                     QueryString = """
@@ -211,27 +350,7 @@ internal sealed class GraphQLQueryFieldConverterTests
 
             yield return new TestCaseData(
                 testNestedGraphQLFieldDefinition,
-                new GraphQLUserDefinedTypes
-                {
-                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
-                    {
-                        {
-                            testGraphQLEnumTypeDefinition.Name.StringValue,
-                            testGraphQLEnumTypeDefinition
-                        }
-                    },
-                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
-                    {
-                        {
-                            testGraphQLObjectDefinition.Name.StringValue,
-                            testGraphQLObjectDefinition
-                        },
-                        {
-                            testGraphQLObjectDefinitionWithNesting.Name.StringValue,
-                            testGraphQLObjectDefinitionWithNesting
-                        }
-                    }
-                },
+                testGraphQLUserDefinedTypes,
                 new GraphQLQueryFieldType(testNestedGraphQLFieldDefinition)
                 {
                     QueryString = """
@@ -276,27 +395,7 @@ internal sealed class GraphQLQueryFieldConverterTests
 
             yield return new TestCaseData(
                 testGraphQLFieldDefinitionWithArguments,
-                new GraphQLUserDefinedTypes
-                {
-                    GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
-                    {
-                        {
-                            testGraphQLEnumTypeDefinition.Name.StringValue,
-                            testGraphQLEnumTypeDefinition
-                        }
-                    },
-                    GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
-                    {
-                        {
-                            testGraphQLObjectDefinition.Name.StringValue,
-                            testGraphQLObjectDefinition
-                        },
-                        {
-                            testGraphQLObjectDefinitionWithNesting.Name.StringValue,
-                            testGraphQLObjectDefinitionWithNesting
-                        }
-                    }
-                },
+                testGraphQLUserDefinedTypes,
                 new GraphQLQueryFieldType(testGraphQLFieldDefinitionWithArguments)
                 {
                     QueryString = """
@@ -311,6 +410,79 @@ internal sealed class GraphQLQueryFieldConverterTests
                                 """
                 }
             ).SetName("Converter is able to convert simple query with arguments.");
+
+            var testGraphQLFieldDefinitionWithNestedArguments = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("personWithFriendsById"),
+                Type = new GraphQLNamedType
+                {
+                    Name = new GraphQLName("PersonWithFriendsWithArguments")
+                },
+                Arguments = new GraphQLArgumentsDefinition
+                {
+                    Items = new List<GraphQLInputValueDefinition>
+                    {
+                        new()
+                        {
+                            Name = new GraphQLName("id"),
+                            Type = new GraphQLNamedType
+                            {
+                                Name = new GraphQLName("Int")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var testGraphQLFieldDefinitionWithScalarArguments = new GraphQLFieldDefinition()
+            {
+                Name = new GraphQLName("personWithFavoriteColors"),
+                Type = new GraphQLNamedType
+                {
+                    Name = new GraphQLName("PersonWithFavoriteColors")
+                }
+            };
+
+            yield return new TestCaseData(
+                testGraphQLFieldDefinitionWithNestedArguments,
+                testGraphQLUserDefinedTypes,
+                new GraphQLQueryFieldType(testGraphQLFieldDefinitionWithNestedArguments)
+                {
+                    QueryString = """
+                                query PersonWithFriendsByIdTest($id: Int, $ids: [String], $location: String!) {
+                                  personWithFriendsById(id: $id) {
+                                    id
+                                    name
+                                    friends(ids: $ids, location: $location) {
+                                      id
+                                      name
+                                      favoriteNumber
+                                      favoriteColor
+                                    }
+                                  }
+                                }
+                                """
+                }
+            ).SetName("Converter is able to convert simple query with nested arguments.");
+
+
+            yield return new TestCaseData(
+                testGraphQLFieldDefinitionWithScalarArguments,
+                testGraphQLUserDefinedTypes,
+                new GraphQLQueryFieldType(testGraphQLFieldDefinitionWithScalarArguments)
+                {
+                    QueryString = """
+                                query PersonWithFavoriteColorsTest($filter: [String]) {
+                                  personWithFavoriteColors {
+                                    id
+                                    name
+                                    favoriteNumber
+                                    favoriteColors(filter: $filter)
+                                  }
+                                }
+                                """
+                }
+            ).SetName("Converter is able to convert simple query with scalar arguments.");
         }
     }
 }


### PR DESCRIPTION
## Description

- Handle scalar fields which have arguments
- Fix argument formatting (previously missing spaces after commas in argument list)
- Refactor `GraphQLQueryFieldConverter` to abstract shared functionality into dedicated methods
- New test cases

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
