### PR TITLE
Cleanup

### DIFF
--- a/src/GraphQLToKarate.Application/Program.cs
+++ b/src/GraphQLToKarate.Application/Program.cs
@@ -1,7 +1,7 @@
 ﻿using GraphQLToKarate.Library;
 using GraphQLToKarate.Library.Converters;
 
-var graphql = """
+const string graphQLSchema = """
     interface FooInterface {
         id: String!
         name: String!
@@ -103,10 +103,10 @@ var graphql = """
 
 var converter = new Converter(
     new GraphQLTypeDefinitionConverter(new GraphQLTypeConverterFactory()),
-    new GraphQLFieldDefinitionDefinitionConverter()
+    new GraphQLFieldDefinitionConverter()
 );
 
-var (karateObjects, graphQLQueryFields) = converter.Convert(graphql);
+var (karateObjects, graphQLQueryFields) = converter.Convert(graphQLSchema);
 
 foreach (var graphQLQueryField in graphQLQueryFields)
 {

--- a/src/GraphQLToKarate.Library/Converters/GraphQLFieldDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLFieldDefinitionConverter.cs
@@ -6,7 +6,8 @@ using GraphQLToKarate.Library.Extensions;
 
 namespace GraphQLToKarate.Library.Converters;
 
-public sealed class GraphQLFieldDefinitionDefinitionConverter : IGraphQLFieldDefinitionConverter
+/// <inheritdoc cref="IGraphQLFieldDefinitionConverter"/>
+public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionConverter
 {
     public GraphQLQueryFieldType Convert(
         GraphQLFieldDefinition graphQLFieldDefinition,
@@ -139,7 +140,7 @@ public sealed class GraphQLFieldDefinitionDefinitionConverter : IGraphQLFieldDef
         IGraphQLInputValueDefinitionConverter graphQLInputValueDefinitionConverter,
         StringBuilder stringBuilder)
     {
-        if (!(graphQLFieldDefinition.Arguments?.Any() ?? false))
+        if (!graphQLFieldDefinition.HasArguments())
         {
             return;
         }
@@ -150,10 +151,10 @@ public sealed class GraphQLFieldDefinitionDefinitionConverter : IGraphQLFieldDef
         {
             var graphQLArgumentType = graphQLInputValueDefinitionConverter.Convert(argument);
 
-            stringBuilder.Append($"{graphQLArgumentType.ArgumentName}: ${graphQLArgumentType.VariableName}{SchemaToken.Comma} ");
+            stringBuilder.Append($"{graphQLArgumentType.ArgumentName}: {graphQLArgumentType.VariableName}{SchemaToken.Comma} ");
         }
 
-        stringBuilder.TrimEnd(2);
+        stringBuilder.TrimEnd(2); // remove trailing comma + space
         stringBuilder.Append(SchemaToken.CloseParen);
     }
 
@@ -174,10 +175,10 @@ public sealed class GraphQLFieldDefinitionDefinitionConverter : IGraphQLFieldDef
 
             foreach (var graphQLArgumentType in graphQLArgumentTypes)
             {
-                operationStringBuilder.Append($"${graphQLArgumentType.VariableName}: {graphQLArgumentType.VariableTypeName}{SchemaToken.Comma} ");
+                operationStringBuilder.Append($"{graphQLArgumentType.VariableName}: {graphQLArgumentType.VariableTypeName}{SchemaToken.Comma} ");
             }
 
-            operationStringBuilder.TrimEnd(2);
+            operationStringBuilder.TrimEnd(2); // remove trailing comma + space
             operationStringBuilder.Append(SchemaToken.CloseParen);
         }
 

--- a/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
@@ -5,6 +5,7 @@ using GraphQLToKarate.Library.Types;
 
 namespace GraphQLToKarate.Library.Converters;
 
+/// <inheritdoc cref="IGraphQLInputValueDefinitionConverter"/>
 internal sealed class GraphQLInputValueDefinitionConverter : IGraphQLInputValueDefinitionConverter
 {
     private readonly ICollection<GraphQLArgumentTypeBase> _graphQLVariableTypes = new List<GraphQLArgumentTypeBase>();
@@ -90,6 +91,6 @@ internal sealed class GraphQLInputValueDefinitionConverter : IGraphQLInputValueD
 
         _reservedVariableNames.Add(uniqueInputValueDefinitionName);
 
-        return uniqueInputValueDefinitionName;
+        return $"${uniqueInputValueDefinitionName}";
     }
 }

--- a/src/GraphQLToKarate.Library/Converters/GraphQLListTypeConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLListTypeConverter.cs
@@ -4,6 +4,7 @@ using GraphQLToKarate.Library.Types;
 
 namespace GraphQLToKarate.Library.Converters;
 
+/// <inheritdoc cref="IGraphQLTypeConverter"/>
 internal sealed class GraphQLListTypeConverter : IGraphQLTypeConverter
 {
     private readonly IGraphQLTypeConverterFactory _graphQLTypeConverterFactory;

--- a/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverterFactory.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverterFactory.cs
@@ -1,5 +1,6 @@
 ﻿namespace GraphQLToKarate.Library.Converters;
 
+/// <inheritdoc cref="IGraphQLTypeConverterFactory"/>
 public sealed class GraphQLTypeConverterFactory : IGraphQLTypeConverterFactory
 {
     private IGraphQLTypeConverter? _graphQLTypeConverter;

--- a/src/GraphQLToKarate.Library/Converters/IGraphQLInputValueDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/IGraphQLInputValueDefinitionConverter.cs
@@ -3,8 +3,16 @@ using GraphQLToKarate.Library.Types;
 
 namespace GraphQLToKarate.Library.Converters;
 
+/// <summary>
+///     Converts <see cref="GraphQLInputValueDefinition"/> instances to <see cref="GraphQLArgumentTypeBase"/>.
+/// </summary>
 public interface IGraphQLInputValueDefinitionConverter
 {
+    /// <summary>
+    ///     Convert the given <see cref="GraphQLInputValueDefinition"/> to a <see cref="GraphQLArgumentTypeBase"/>.
+    /// </summary>
+    /// <param name="graphQLInputValueDefinition">The input value definition to convert.</param>
+    /// <returns>The converted GraphQL argument type.</returns>
     GraphQLArgumentTypeBase Convert(GraphQLInputValueDefinition graphQLInputValueDefinition);
 
     ICollection<GraphQLArgumentTypeBase> GetAllConverted();

--- a/src/GraphQLToKarate.Library/Extensions/GraphQLTypeExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/GraphQLTypeExtensions.cs
@@ -1,10 +1,14 @@
 ﻿using GraphQLParser.AST;
-using GraphQLToKarate.Library.Exceptions;
 
 namespace GraphQLToKarate.Library.Extensions;
 
 internal static class GraphQLTypeExtensions
 {
+    /// <summary>
+    ///     Retrieve the associated type name contained by the given <see cref="GraphQLType"/>.
+    /// </summary>
+    /// <param name="graphQLType">The <see cref="GraphQLType"/> to retrieve the type name from.</param>
+    /// <returns>The type name contained by the given <see cref="GraphQLType"/>.</returns>
     public static string GetTypeName(this GraphQLType graphQLType)
     {
         while (true)
@@ -20,8 +24,6 @@ internal static class GraphQLTypeExtensions
                 case GraphQLNamedType namedType:
                     return namedType.Name.StringValue;
             }
-
-            throw new InvalidGraphQLTypeException();
         }
     }
 }

--- a/src/GraphQLToKarate.Library/Extensions/HasArgumentsDefinitionNodeExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/HasArgumentsDefinitionNodeExtensions.cs
@@ -1,0 +1,13 @@
+﻿using GraphQLParser.AST;
+
+namespace GraphQLToKarate.Library.Extensions;
+
+internal static class HasArgumentsDefinitionNodeExtensions
+{
+    /// <summary>
+    ///     Returns whether the <see cref="IHasArgumentsDefinitionNode"/> has arguments or not.
+    /// </summary>
+    /// <param name="source">The source node to check.</param>
+    /// <returns>Whether the <see cref="IHasArgumentsDefinitionNode"/> actually has arguments.</returns>
+    public static bool HasArguments(this IHasArgumentsDefinitionNode source) => source.Arguments?.Any() ?? false;
+}

--- a/src/GraphQLToKarate.Library/Extensions/StringBuilderExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/StringBuilderExtensions.cs
@@ -4,5 +4,10 @@ namespace GraphQLToKarate.Library.Extensions;
 
 internal static class StringBuilderExtensions
 {
-    public static void TrimEnd(this StringBuilder source, int length) => source.Remove(source.Length - length, length);
+    /// <summary>
+    ///     Trims the last <paramref name="count"/> characters from the end of the <see cref="StringBuilder"/>.
+    /// </summary>
+    /// <param name="source">The <see cref="StringBuilder"/> to manipulate.</param>
+    /// <param name="count">The count of characters to trim from the end of the <see cref="StringBuilder"/>.</param>
+    public static void TrimEnd(this StringBuilder source, int count) => source.Remove(source.Length - count, count);
 }

--- a/src/GraphQLToKarate.Library/Types/KarateObject.cs
+++ b/src/GraphQLToKarate.Library/Types/KarateObject.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using GraphQLToKarate.Library.Extensions;
 using GraphQLToKarate.Library.Tokens;
 
 namespace GraphQLToKarate.Library.Types;
@@ -38,7 +39,7 @@ public sealed class KarateObject
             stringBuilder.Append(SchemaToken.Comma);
         }
 
-        stringBuilder.Remove(stringBuilder.Length - 1, 1);
+        stringBuilder.TrimEnd(1); // remove trailing comma
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append(SchemaToken.CloseBrace);
 

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLFieldDefinitionConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLFieldDefinitionConverterTests.cs
@@ -7,12 +7,12 @@ using NUnit.Framework;
 namespace GraphQLToKarate.Tests.Converters;
 
 [TestFixture]
-internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
+internal sealed class GraphQLFieldDefinitionConverterTests
 {
     private IGraphQLFieldDefinitionConverter? _subjectUnderTest;
 
     [SetUp]
-    public void SetUp() => _subjectUnderTest = new GraphQLFieldDefinitionDefinitionConverter();
+    public void SetUp() => _subjectUnderTest = new GraphQLFieldDefinitionConverter();
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
@@ -37,16 +37,7 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
     {
         get
         {
-            var testGraphQLFieldDefinition = new GraphQLFieldDefinition
-            {
-                Name = new GraphQLName("person"),
-                Type = new GraphQLNamedType
-                {
-                    Name = new GraphQLName("Person")
-                }
-            };
-
-            var testGraphQLObjectDefinition = new GraphQLObjectTypeDefinition
+            var person = new GraphQLObjectTypeDefinition
             {
                 Name = new GraphQLName("Person"),
                 Fields = new GraphQLFieldsDefinition
@@ -89,7 +80,7 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                 }
             };
 
-            var testGraphQLObjectDefinitionWithNesting = new GraphQLObjectTypeDefinition
+            var personWithFriends = new GraphQLObjectTypeDefinition
             {
                 Name = new GraphQLName("PersonWithFriends"),
                 Fields = new GraphQLFieldsDefinition
@@ -119,7 +110,7 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                             {
                                 Type = new GraphQLNamedType
                                 {
-                                    Name = new GraphQLName("Person")
+                                    Name = new GraphQLName(person.Name)
                                 }
                             }
                         }
@@ -127,7 +118,7 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                 }
             };
 
-            var testGraphQLObjectDefinitionWithNestedFieldArguments = new GraphQLObjectTypeDefinition
+            var personWithFriendsWithArguments = new GraphQLObjectTypeDefinition
             {
                 Name = new GraphQLName("PersonWithFriendsWithArguments"),
                 Fields = new GraphQLFieldsDefinition
@@ -157,7 +148,7 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                             {
                                 Type = new GraphQLNamedType
                                 {
-                                    Name = new GraphQLName("Person")
+                                    Name = new GraphQLName(person.Name)
                                 }
                             },
                             Arguments = new GraphQLArgumentsDefinition
@@ -193,7 +184,7 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                 }
             };
 
-            var testGraphQLObjectDefinitionWithScalarFieldArguments = new GraphQLObjectTypeDefinition
+            var personWithFavoriteColorsWithArguments = new GraphQLObjectTypeDefinition
             {
                 Name = new GraphQLName("PersonWithFavoriteColors"),
                 Fields = new GraphQLFieldsDefinition
@@ -256,7 +247,7 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                 }
             };
 
-            var testGraphQLInterfaceTypeDefinition = new GraphQLInterfaceTypeDefinition
+            var personInterface = new GraphQLInterfaceTypeDefinition
             {
                 Name = new GraphQLName("PersonInterface"),
                 Fields = new GraphQLFieldsDefinition
@@ -283,7 +274,7 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                 }
             };
 
-            var testGraphQLInterfaceTypeDefinitionWithNesting = new GraphQLInterfaceTypeDefinition
+            var personInterfaceWithFriend = new GraphQLInterfaceTypeDefinition
             {
                 Name = new GraphQLName("NestedPersonInterface"),
                 Fields = new GraphQLFieldsDefinition
@@ -311,14 +302,14 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                             Name = new GraphQLName("friend"),
                             Type = new GraphQLNamedType
                             {
-                                Name = new GraphQLName("PersonInterface")
+                                Name = new GraphQLName(personInterface.Name)
                             }
                         }
                     }
                 }
             };
 
-            var testGraphQLEnumTypeDefinition = new GraphQLEnumTypeDefinition()
+            var colors = new GraphQLEnumTypeDefinition
             {
                 Name = new GraphQLName("Color"),
                 Values = new GraphQLEnumValuesDefinition
@@ -353,51 +344,60 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                 }
             };
 
-            var testGraphQLUserDefinedTypes = new GraphQLUserDefinedTypes
+            var graphQLUserDefinedTypes = new GraphQLUserDefinedTypes
             {
                 GraphQLEnumTypeDefinitionsByName = new Dictionary<string, GraphQLEnumTypeDefinition>
                 {
                     {
-                        testGraphQLEnumTypeDefinition.Name.StringValue,
-                        testGraphQLEnumTypeDefinition
+                        colors.Name.StringValue,
+                        colors
                     }
                 },
                 GraphQLObjectTypeDefinitionsByName = new Dictionary<string, GraphQLObjectTypeDefinition>
                 {
                     {
-                        testGraphQLObjectDefinition.Name.StringValue,
-                        testGraphQLObjectDefinition
+                        person.Name.StringValue,
+                        person
                     },
                     {
-                        testGraphQLObjectDefinitionWithNestedFieldArguments.Name.StringValue,
-                        testGraphQLObjectDefinitionWithNestedFieldArguments
+                        personWithFriendsWithArguments.Name.StringValue,
+                        personWithFriendsWithArguments
                     },
                     {
-                        testGraphQLObjectDefinitionWithNesting.Name.StringValue,
-                        testGraphQLObjectDefinitionWithNesting
+                        personWithFriends.Name.StringValue,
+                        personWithFriends
                     },
                     {
-                        testGraphQLObjectDefinitionWithScalarFieldArguments.Name.StringValue,
-                        testGraphQLObjectDefinitionWithScalarFieldArguments
+                        personWithFavoriteColorsWithArguments.Name.StringValue,
+                        personWithFavoriteColorsWithArguments
                     }
                 },
                 GraphQLInterfaceTypeDefinitionsByName = new Dictionary<string, GraphQLInterfaceTypeDefinition>
                 {
                     {
-                        testGraphQLInterfaceTypeDefinition.Name.StringValue, 
-                        testGraphQLInterfaceTypeDefinition
+                        personInterface.Name.StringValue, 
+                        personInterface
                     },
                     {
-                        testGraphQLInterfaceTypeDefinitionWithNesting.Name.StringValue,
-                        testGraphQLInterfaceTypeDefinitionWithNesting
+                        personInterfaceWithFriend.Name.StringValue,
+                        personInterfaceWithFriend
                     }
                 }
             };
 
+            var personQueryFieldDefinition = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("person"),
+                Type = new GraphQLNamedType
+                {
+                    Name = new GraphQLName(person.Name)
+                }
+            };
+
             yield return new TestCaseData(
-                testGraphQLFieldDefinition,
-                testGraphQLUserDefinedTypes,
-                new GraphQLQueryFieldType(testGraphQLFieldDefinition)
+                personQueryFieldDefinition,
+                graphQLUserDefinedTypes,
+                new GraphQLQueryFieldType(personQueryFieldDefinition)
                 {
                     QueryString = """
                                 query PersonTest {
@@ -412,19 +412,19 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                 }
             ).SetName("Converter is able to convert simple query.");
 
-            var testNestedGraphQLFieldDefinition = new GraphQLFieldDefinition
+            var personWithFriendsQueryFieldDefinition = new GraphQLFieldDefinition
             {
                 Name = new GraphQLName("personWithFriends"),
                 Type = new GraphQLNamedType
                 {
-                    Name = new GraphQLName("PersonWithFriends")
+                    Name = new GraphQLName(personWithFriends.Name)
                 }
             };
 
             yield return new TestCaseData(
-                testNestedGraphQLFieldDefinition,
-                testGraphQLUserDefinedTypes,
-                new GraphQLQueryFieldType(testNestedGraphQLFieldDefinition)
+                personWithFriendsQueryFieldDefinition,
+                graphQLUserDefinedTypes,
+                new GraphQLQueryFieldType(personWithFriendsQueryFieldDefinition)
                 {
                     QueryString = """
                                 query PersonWithFriendsTest {
@@ -443,12 +443,12 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                 }
             ).SetName("Converter is able to convert nested query.");
 
-            var testGraphQLFieldDefinitionWithArguments = new GraphQLFieldDefinition
+            var personWithFriendsWithArgumentsGraphQLQueryFieldDefinition = new GraphQLFieldDefinition
             {
                 Name = new GraphQLName("personById"),
                 Type = new GraphQLNamedType
                 {
-                    Name = new GraphQLName("Person")
+                    Name = new GraphQLName(person.Name)
                 },
                 Arguments = new GraphQLArgumentsDefinition
                 {
@@ -467,9 +467,9 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
             };
 
             yield return new TestCaseData(
-                testGraphQLFieldDefinitionWithArguments,
-                testGraphQLUserDefinedTypes,
-                new GraphQLQueryFieldType(testGraphQLFieldDefinitionWithArguments)
+                personWithFriendsWithArgumentsGraphQLQueryFieldDefinition,
+                graphQLUserDefinedTypes,
+                new GraphQLQueryFieldType(personWithFriendsWithArgumentsGraphQLQueryFieldDefinition)
                 {
                     QueryString = """
                                 query PersonByIdTest($id: Int) {
@@ -484,7 +484,7 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                 }
             ).SetName("Converter is able to convert simple query with arguments.");
 
-            var testGraphQLFieldDefinitionWithNestedArguments = new GraphQLFieldDefinition
+            var personWithFriendsWithNestedArgumentsGraphQLQueryFieldDefinition = new GraphQLFieldDefinition
             {
                 Name = new GraphQLName("personWithFriendsById"),
                 Type = new GraphQLNamedType
@@ -507,19 +507,19 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                 }
             };
 
-            var testGraphQLFieldDefinitionWithScalarArguments = new GraphQLFieldDefinition()
+            var personWithFavoriteColorsGraphQLQueryFieldDefinition = new GraphQLFieldDefinition
             {
                 Name = new GraphQLName("personWithFavoriteColors"),
                 Type = new GraphQLNamedType
                 {
-                    Name = new GraphQLName("PersonWithFavoriteColors")
+                    Name = new GraphQLName(personWithFavoriteColorsWithArguments.Name)
                 }
             };
 
             yield return new TestCaseData(
-                testGraphQLFieldDefinitionWithNestedArguments,
-                testGraphQLUserDefinedTypes,
-                new GraphQLQueryFieldType(testGraphQLFieldDefinitionWithNestedArguments)
+                personWithFriendsWithNestedArgumentsGraphQLQueryFieldDefinition,
+                graphQLUserDefinedTypes,
+                new GraphQLQueryFieldType(personWithFriendsWithNestedArgumentsGraphQLQueryFieldDefinition)
                 {
                     QueryString = """
                                 query PersonWithFriendsByIdTest($id: Int, $ids: [String], $location: String!) {
@@ -540,9 +540,9 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
 
 
             yield return new TestCaseData(
-                testGraphQLFieldDefinitionWithScalarArguments,
-                testGraphQLUserDefinedTypes,
-                new GraphQLQueryFieldType(testGraphQLFieldDefinitionWithScalarArguments)
+                personWithFavoriteColorsGraphQLQueryFieldDefinition,
+                graphQLUserDefinedTypes,
+                new GraphQLQueryFieldType(personWithFavoriteColorsGraphQLQueryFieldDefinition)
                 {
                     QueryString = """
                                 query PersonWithFavoriteColorsTest($filter: [String]) {
@@ -558,19 +558,19 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
             ).SetName("Converter is able to convert simple query with scalar field arguments.");
 
 
-            var testGraphQLFieldDefinitionWithInterface = new GraphQLFieldDefinition
+            var personInterfaceQueryGraphQLFieldDefinition = new GraphQLFieldDefinition
             {
                 Name = new GraphQLName("personInterface"),
                 Type = new GraphQLNamedType
                 {
-                    Name = new GraphQLName("PersonInterface")
+                    Name = new GraphQLName(personInterface.Name)
                 }
             };
 
             yield return new TestCaseData(
-                testGraphQLFieldDefinitionWithInterface,
-                testGraphQLUserDefinedTypes,
-                new GraphQLQueryFieldType(testGraphQLFieldDefinitionWithInterface)
+                personInterfaceQueryGraphQLFieldDefinition,
+                graphQLUserDefinedTypes,
+                new GraphQLQueryFieldType(personInterfaceQueryGraphQLFieldDefinition)
                 {
                     QueryString = """
                                 query PersonInterfaceTest {
@@ -583,19 +583,19 @@ internal sealed class GraphQLFieldDefinitionDefinitionConverterTests
                 }
             ).SetName("Converter is able to convert simple query with interface return type.");
 
-            var testGraphQLFieldDefinitionWithNestedInterface = new GraphQLFieldDefinition
+            var nestedPersonInterfaceGraphQLQueryFieldDefinition = new GraphQLFieldDefinition
             {
                 Name = new GraphQLName("nestedPersonInterface"),
                 Type = new GraphQLNamedType
                 {
-                    Name = new GraphQLName(testGraphQLInterfaceTypeDefinitionWithNesting.Name)
+                    Name = new GraphQLName(personInterfaceWithFriend.Name)
                 }
             };
 
             yield return new TestCaseData(
-                testGraphQLFieldDefinitionWithNestedInterface,
-                testGraphQLUserDefinedTypes,
-                new GraphQLQueryFieldType(testGraphQLFieldDefinitionWithNestedInterface)
+                nestedPersonInterfaceGraphQLQueryFieldDefinition,
+                graphQLUserDefinedTypes,
+                new GraphQLQueryFieldType(nestedPersonInterfaceGraphQLQueryFieldDefinition)
                 {
                     QueryString = """
                                 query NestedPersonInterfaceTest {

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLInputValueDefinitionConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLInputValueDefinitionConverterTests.cs
@@ -42,7 +42,7 @@ internal sealed class GraphQLInputValueDefinitionConverterTests
                     }
                 },
                 typeof(GraphQLArgumentType),
-                "age",
+                "$age",
                 "Int"
             ).SetName("With Named Type");
 
@@ -59,7 +59,7 @@ internal sealed class GraphQLInputValueDefinitionConverterTests
                     }
                 },
                 typeof(GraphQLListArgumentType),
-                "hobbies",
+                "$hobbies",
                 "[String]"
             ).SetName("With List Type");
 
@@ -76,7 +76,7 @@ internal sealed class GraphQLInputValueDefinitionConverterTests
                     }
                 },
                 typeof(GraphQLNonNullArgumentType),
-                "email",
+                "$email",
                 "String!"
             ).SetName("With Non-Null Type");
 
@@ -99,7 +99,7 @@ internal sealed class GraphQLInputValueDefinitionConverterTests
                     }
                 },
                 typeof(GraphQLNonNullArgumentType),
-                "address",
+                "$address",
                 "[String!]!"
             ).SetName("With Non-Null List Type and Named Type");
         }
@@ -144,8 +144,8 @@ internal sealed class GraphQLInputValueDefinitionConverterTests
         var result3 = converter.Convert(inputValueDefinition3);
 
         // assert
-        result1.VariableName.Should().Be("age");
-        result2.VariableName.Should().Be("age1");
-        result3.VariableName.Should().Be("age2");
+        result1.VariableName.Should().Be("$age");
+        result2.VariableName.Should().Be("$age1");
+        result3.VariableName.Should().Be("$age2");
     }
 }


### PR DESCRIPTION
## Description

- Add missing docs and missing `inheritdoc`
- Implement extension method for checking whether a `IHasArgumentsDefinitionNode` actually has any arguments
- Adjust GraphQL variable name generation
- Clean up variable names and reuse variables in `GraphQLFieldDefinitionConverterTests`

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
