### PR TITLE
More Flexible Type Conversions

### DIFF
--- a/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverter.cs
@@ -25,10 +25,7 @@ internal sealed class GraphQLTypeConverter : IGraphQLTypeConverter
                 KarateToken.String,
             { } graphQLTypeName when graphQLDocumentAdapter.IsGraphQLTypeDefinitionWithFields(graphQLTypeName) =>
                 $"{graphQLTypeName.FirstCharToLower()}Schema",
-            _ => throw new ArgumentException(
-                $"Unknown GraphQL type name for GraphQL field {graphQLFieldName}!",
-                nameof(graphQLType)
-            )
+            _ => KarateToken.Present
         };
 
         return new KarateType(karateTypeSchema, graphQLFieldName);

--- a/src/GraphQLToKarate.Library/Tokens/KarateToken.cs
+++ b/src/GraphQLToKarate.Library/Tokens/KarateToken.cs
@@ -16,6 +16,8 @@ internal static class KarateToken
 
     public const string Object = "object";
 
+    public const string Present = "present";
+
     public const string Null = "##";
 
     public const string NonNull = "#";

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLTypeConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLTypeConverterTests.cs
@@ -175,6 +175,16 @@ internal sealed class GraphQLTypeConverterTests
                 new GraphQLDocumentAdapter(graphQLDocumentWithEnumAndCustomAndInterfaceTypeDefinition),
                 new KarateType($"{interfaceTypeName.FirstCharToLower()}Schema", testFieldName)
             ).SetName("Custom GraphQL type is converted to custom Karate type.");
+
+            yield return new TestCaseData(
+                testFieldName,
+                new GraphQLNamedType
+                {
+                    Name = new GraphQLName("Unknown")
+                },
+                emptyGraphQLDocumentAdapter,
+                new KarateType(KarateToken.Present, testFieldName)
+            ).SetName("Unknown GraphQL type is converted to present Karate type.");
         }
     }
 }


### PR DESCRIPTION
## Description

Instead of throwing an exception when an unknown type is encountered, convert it to a `present` Karate type, which just ensures that _something_ is present, regardless of the actual type.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
