### PR TITLE
Add Arguments to Query Type Output

### DIFF
--- a/src/GraphQLToKarate.Library/Converters/GraphQLFieldDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLFieldDefinitionConverter.cs
@@ -16,13 +16,18 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
     {
         IGraphQLInputValueDefinitionConverter graphQLInputValueDefinitionConverter = new GraphQLInputValueDefinitionConverter();
 
+        var queryString = Convert(
+            graphQLFieldDefinition,
+            graphQLDocumentAdapter,
+            graphQLInputValueDefinitionConverter
+        );
+
+        var arguments = graphQLInputValueDefinitionConverter.GetAllConverted();
+
         return new GraphQLQueryFieldType(graphQLFieldDefinition)
         {
-            QueryString = Convert(
-                graphQLFieldDefinition, 
-                graphQLDocumentAdapter,
-                graphQLInputValueDefinitionConverter
-            )
+            QueryString = queryString,
+            Arguments = arguments
         };
     }
 

--- a/src/GraphQLToKarate.Library/Types/GraphQLArgumentType.cs
+++ b/src/GraphQLToKarate.Library/Types/GraphQLArgumentType.cs
@@ -1,6 +1,6 @@
 ﻿namespace GraphQLToKarate.Library.Types;
 
-internal sealed class GraphQLArgumentType : GraphQLArgumentTypeBase
+public sealed class GraphQLArgumentType : GraphQLArgumentTypeBase
 {
     public GraphQLArgumentType(
         string argumentName,

--- a/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
+++ b/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
@@ -13,5 +13,7 @@ public sealed class GraphQLQueryFieldType
 
     public required string QueryString { get; init; }
 
+    public required ICollection<GraphQLArgumentTypeBase> Arguments { get; init; }
+
     public GraphQLQueryFieldType(GraphQLFieldDefinition queryField) => _queryField = queryField;
 }

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLFieldDefinitionConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLFieldDefinitionConverterTests.cs
@@ -2,6 +2,7 @@
 using GraphQLParser.AST;
 using GraphQLToKarate.Library.Adapters;
 using GraphQLToKarate.Library.Converters;
+using GraphQLToKarate.Library.Tokens;
 using GraphQLToKarate.Library.Types;
 using NUnit.Framework;
 
@@ -384,7 +385,8 @@ internal sealed class GraphQLFieldDefinitionConverterTests
                                     favoriteColor
                                   }
                                 }
-                                """
+                                """,
+                    Arguments = new List<GraphQLArgumentTypeBase>()
                 }
             ).SetName("Converter is able to convert simple query.");
 
@@ -415,7 +417,8 @@ internal sealed class GraphQLFieldDefinitionConverterTests
                                     }
                                   }
                                 }
-                                """
+                                """,
+                    Arguments = new List<GraphQLArgumentTypeBase>()
                 }
             ).SetName("Converter is able to convert nested query.");
 
@@ -456,7 +459,11 @@ internal sealed class GraphQLFieldDefinitionConverterTests
                                     favoriteColor
                                   }
                                 }
-                                """
+                                """,
+                    Arguments = new List<GraphQLArgumentTypeBase>
+                    {
+                        new GraphQLArgumentType("id", "$id", GraphQLToken.Int)
+                    }
                 }
             ).SetName("Converter is able to convert simple query with arguments.");
 
@@ -510,7 +517,13 @@ internal sealed class GraphQLFieldDefinitionConverterTests
                                     }
                                   }
                                 }
-                                """
+                                """,
+                    Arguments = new List<GraphQLArgumentTypeBase>
+                    {
+                        new GraphQLArgumentType("id", "$id", GraphQLToken.Int),
+                        new GraphQLListArgumentType(new GraphQLArgumentType("ids", "$ids", GraphQLToken.String)),
+                        new GraphQLNonNullArgumentType(new GraphQLArgumentType("location", "$location", GraphQLToken.String))
+                    }
                 }
             ).SetName("Converter is able to convert nested query with nested field arguments.");
 
@@ -529,7 +542,13 @@ internal sealed class GraphQLFieldDefinitionConverterTests
                                     favoriteColors(filter: $filter)
                                   }
                                 }
-                                """
+                                """,
+                    Arguments = new List<GraphQLArgumentTypeBase>
+                    {
+                        new GraphQLListArgumentType(
+                            new GraphQLArgumentType("filter", "$filter", GraphQLToken.String)
+                        )
+                    }
                 }
             ).SetName("Converter is able to convert simple query with scalar field arguments.");
 
@@ -555,7 +574,8 @@ internal sealed class GraphQLFieldDefinitionConverterTests
                                     name
                                   }
                                 }
-                                """
+                                """,
+                    Arguments = new List<GraphQLArgumentTypeBase>()
                 }
             ).SetName("Converter is able to convert simple query with interface return type.");
 
@@ -584,7 +604,8 @@ internal sealed class GraphQLFieldDefinitionConverterTests
                                     }
                                   }
                                 }
-                                """
+                                """,
+                    Arguments = new List<GraphQLArgumentTypeBase>()
                 }
             ).SetName("Converter is able to convert simple query with nested interface return type.");
         }


### PR DESCRIPTION
## Description

Small change to add query arguments to the generated `GraphQLQueryFieldType` output when converting.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
