### PR TITLE
Scenario Generation

### DIFF
--- a/src/GraphQLToKarate.Application/Program.cs
+++ b/src/GraphQLToKarate.Application/Program.cs
@@ -1,5 +1,6 @@
 ﻿using GraphQLToKarate.Library;
 using GraphQLToKarate.Library.Converters;
+using GraphQLToKarate.Library.Features;
 
 const string graphQLSchema = """
     interface FooInterface {
@@ -70,7 +71,7 @@ const string graphQLSchema = """
         todos(
           "Required argument that is a list that cannot contain null values"
           ids: [String!]!
-        ): [FooInterface]
+        ): [FooInterface!]!
 
         nestedTodos(
           ids: [String!]!
@@ -108,17 +109,18 @@ var converter = new Converter(
 
 var (karateObjects, graphQLQueryFields) = converter.Convert(graphQLSchema);
 
-foreach (var graphQLQueryField in graphQLQueryFields)
-{
-    Console.WriteLine($"{graphQLQueryField.Name}: {graphQLQueryField.ReturnTypeName}");
-    Console.WriteLine(graphQLQueryField.QueryString);
-    Console.WriteLine();
-}
+var scenarioBuilder = new ScenarioBuilder();
 
 foreach (var karateObject in karateObjects)
 {
     Console.WriteLine(karateObject.Name);
     Console.WriteLine(karateObject);
+    Console.WriteLine();
+}
+
+foreach (var graphQLQueryField in graphQLQueryFields)
+{
+    Console.WriteLine(scenarioBuilder.Build(graphQLQueryField));
     Console.WriteLine();
 }
 

--- a/src/GraphQLToKarate.Library/Converters/GraphQLFieldDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLFieldDefinitionConverter.cs
@@ -136,7 +136,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
         {
             var graphQLArgumentType = graphQLInputValueDefinitionConverter.Convert(argument);
 
-            stringBuilder.Append($"{graphQLArgumentType.ArgumentName}: {graphQLArgumentType.VariableName}{SchemaToken.Comma} ");
+            stringBuilder.Append($"{graphQLArgumentType.ArgumentName}: ${graphQLArgumentType.VariableName}{SchemaToken.Comma} ");
         }
 
         stringBuilder.TrimEnd(2); // remove trailing comma + space
@@ -160,7 +160,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
 
             foreach (var graphQLArgumentType in graphQLArgumentTypes)
             {
-                operationStringBuilder.Append($"{graphQLArgumentType.VariableName}: {graphQLArgumentType.VariableTypeName}{SchemaToken.Comma} ");
+                operationStringBuilder.Append($"${graphQLArgumentType.VariableName}: {graphQLArgumentType.VariableTypeName}{SchemaToken.Comma} ");
             }
 
             operationStringBuilder.TrimEnd(2); // remove trailing comma + space

--- a/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
@@ -91,6 +91,6 @@ internal sealed class GraphQLInputValueDefinitionConverter : IGraphQLInputValueD
 
         _reservedVariableNames.Add(uniqueInputValueDefinitionName);
 
-        return $"${uniqueInputValueDefinitionName}";
+        return $"{uniqueInputValueDefinitionName}";
     }
 }

--- a/src/GraphQLToKarate.Library/Extensions/StringExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/StringExtensions.cs
@@ -42,4 +42,17 @@ internal static class StringExtensions
             str.AsSpan(1).CopyTo(characters[1..]);
         });
     }
+
+    /// <summary>
+    ///     Indents a <paramref name="source"/> string (including multi-line strings) by the specified <see cref="indent"/> amount.
+    /// </summary>
+    /// <param name="source">The string to manipulate.</param>
+    /// <param name="indent">The amount to indent the string.</param>
+    /// <returns>The source string, indented by the specified <paramref name="indent"/> amount.</returns>
+    public static string Indent(this string source, int indent)
+    {
+        var indentation = new string(' ', indent);
+
+        return indentation + source.Replace(Environment.NewLine, Environment.NewLine + indentation);
+    }
 }

--- a/src/GraphQLToKarate.Library/Features/IScenarioBuilder.cs
+++ b/src/GraphQLToKarate.Library/Features/IScenarioBuilder.cs
@@ -1,0 +1,11 @@
+﻿using GraphQLToKarate.Library.Types;
+
+namespace GraphQLToKarate.Library.Features;
+
+/// <summary>
+///     Builds a Karate API testing scenario in string format.
+/// </summary>
+public interface IScenarioBuilder
+{
+    string Build(GraphQLQueryFieldType graphQLQueryFieldType);
+}

--- a/src/GraphQLToKarate.Library/Features/ScenarioBuilder.cs
+++ b/src/GraphQLToKarate.Library/Features/ScenarioBuilder.cs
@@ -1,0 +1,63 @@
+﻿using GraphQLToKarate.Library.Extensions;
+using GraphQLToKarate.Library.Tokens;
+using GraphQLToKarate.Library.Types;
+using System.Text;
+
+namespace GraphQLToKarate.Library.Features;
+
+/// <inheritdoc cref="IScenarioBuilder"/>
+public class ScenarioBuilder : IScenarioBuilder
+{
+    private const int SingleIndent = 2;
+    private const int DoubleIndent = SingleIndent * 2;
+    private const int TripleIndent = SingleIndent * 3;
+    private const int QuadrupleIndent = SingleIndent * 4;
+
+    public string Build(GraphQLQueryFieldType graphQLQueryFieldType)
+    {
+        var stringBuilder = new StringBuilder();
+
+        stringBuilder.AppendLine($"Scenario: Perform a {graphQLQueryFieldType.Name} query and validate the response");
+        stringBuilder.AppendLine($"* text query = {SchemaToken.TripleQuote}".Indent(SingleIndent));
+        stringBuilder.AppendLine(graphQLQueryFieldType.QueryString.Indent(TripleIndent));
+        stringBuilder.AppendLine($"{SchemaToken.TripleQuote}".Indent(DoubleIndent));
+
+        if (graphQLQueryFieldType.Arguments.Any())
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine($"* text variables = {SchemaToken.TripleQuote}".Indent(SingleIndent));
+            stringBuilder.AppendLine("{".Indent(TripleIndent));
+
+            foreach (var argumentVariable in graphQLQueryFieldType.Arguments)
+            {
+                stringBuilder.AppendLine($"\"{argumentVariable.VariableName}\": <some value>".Indent(QuadrupleIndent));
+            }
+
+            stringBuilder.AppendLine("}".Indent(TripleIndent));
+            stringBuilder.AppendLine($"{SchemaToken.TripleQuote}".Indent(DoubleIndent));
+        }
+
+        stringBuilder.AppendLine();
+        stringBuilder.AppendLine("Given path \"/graphql\"".Indent(SingleIndent));
+        stringBuilder.Append("And request ".Indent(SingleIndent));
+        stringBuilder.Append("{ ");
+        stringBuilder.Append("query: query, ");
+        stringBuilder.Append($"operationName: \"{graphQLQueryFieldType.OperationName}\"");
+
+        if (graphQLQueryFieldType.Arguments.Any())
+        {
+            stringBuilder.Append(", variables: variables");
+        }
+
+        stringBuilder.AppendLine(" }");
+        stringBuilder.AppendLine("When method post".Indent(SingleIndent));
+        stringBuilder.AppendLine("Then status 200".Indent(SingleIndent));
+
+        stringBuilder.Append(graphQLQueryFieldType.IsListReturnType
+            ? $"And match each response.data.{graphQLQueryFieldType.Name} == {graphQLQueryFieldType.ReturnTypeName.FirstCharToLower()}Schema".Indent(SingleIndent)
+            : $"And match response.data.{graphQLQueryFieldType.Name} == {graphQLQueryFieldType.ReturnTypeName.FirstCharToLower()}Schema".Indent(SingleIndent)
+        );
+
+        return stringBuilder.ToString();
+    }
+}

--- a/src/GraphQLToKarate.Library/Tokens/SchemaToken.cs
+++ b/src/GraphQLToKarate.Library/Tokens/SchemaToken.cs
@@ -22,4 +22,6 @@ internal static class SchemaToken
     public const char OpenParen = '(';
 
     public const char CloseParen = ')';
+
+    public const string TripleQuote = "\"\"\"";
 }

--- a/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
+++ b/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
@@ -9,7 +9,14 @@ public sealed class GraphQLQueryFieldType
 
     public string Name => _queryField.Name.StringValue;
 
+    public string OperationName => $"{Name.FirstCharToUpper()}Test";
+
     public string ReturnTypeName => _queryField.Type.GetTypeName();
+
+    public bool IsListReturnType => _queryField.Type is GraphQLListType or GraphQLNonNullType
+    {
+        Type: GraphQLListType
+    };
 
     public required string QueryString { get; init; }
 

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLFieldDefinitionConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLFieldDefinitionConverterTests.cs
@@ -462,7 +462,7 @@ internal sealed class GraphQLFieldDefinitionConverterTests
                                 """,
                     Arguments = new List<GraphQLArgumentTypeBase>
                     {
-                        new GraphQLArgumentType("id", "$id", GraphQLToken.Int)
+                        new GraphQLArgumentType("id", "id", GraphQLToken.Int)
                     }
                 }
             ).SetName("Converter is able to convert simple query with arguments.");
@@ -520,9 +520,9 @@ internal sealed class GraphQLFieldDefinitionConverterTests
                                 """,
                     Arguments = new List<GraphQLArgumentTypeBase>
                     {
-                        new GraphQLArgumentType("id", "$id", GraphQLToken.Int),
-                        new GraphQLListArgumentType(new GraphQLArgumentType("ids", "$ids", GraphQLToken.String)),
-                        new GraphQLNonNullArgumentType(new GraphQLArgumentType("location", "$location", GraphQLToken.String))
+                        new GraphQLArgumentType("id", "id", GraphQLToken.Int),
+                        new GraphQLListArgumentType(new GraphQLArgumentType("ids", "ids", GraphQLToken.String)),
+                        new GraphQLNonNullArgumentType(new GraphQLArgumentType("location", "location", GraphQLToken.String))
                     }
                 }
             ).SetName("Converter is able to convert nested query with nested field arguments.");
@@ -546,7 +546,7 @@ internal sealed class GraphQLFieldDefinitionConverterTests
                     Arguments = new List<GraphQLArgumentTypeBase>
                     {
                         new GraphQLListArgumentType(
-                            new GraphQLArgumentType("filter", "$filter", GraphQLToken.String)
+                            new GraphQLArgumentType("filter", "filter", GraphQLToken.String)
                         )
                     }
                 }

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLInputValueDefinitionConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLInputValueDefinitionConverterTests.cs
@@ -42,7 +42,7 @@ internal sealed class GraphQLInputValueDefinitionConverterTests
                     }
                 },
                 typeof(GraphQLArgumentType),
-                "$age",
+                "age",
                 "Int"
             ).SetName("With Named Type");
 
@@ -59,7 +59,7 @@ internal sealed class GraphQLInputValueDefinitionConverterTests
                     }
                 },
                 typeof(GraphQLListArgumentType),
-                "$hobbies",
+                "hobbies",
                 "[String]"
             ).SetName("With List Type");
 
@@ -76,7 +76,7 @@ internal sealed class GraphQLInputValueDefinitionConverterTests
                     }
                 },
                 typeof(GraphQLNonNullArgumentType),
-                "$email",
+                "email",
                 "String!"
             ).SetName("With Non-Null Type");
 
@@ -99,7 +99,7 @@ internal sealed class GraphQLInputValueDefinitionConverterTests
                     }
                 },
                 typeof(GraphQLNonNullArgumentType),
-                "$address",
+                "address",
                 "[String!]!"
             ).SetName("With Non-Null List Type and Named Type");
         }
@@ -144,8 +144,8 @@ internal sealed class GraphQLInputValueDefinitionConverterTests
         var result3 = converter.Convert(inputValueDefinition3);
 
         // assert
-        result1.VariableName.Should().Be("$age");
-        result2.VariableName.Should().Be("$age1");
-        result3.VariableName.Should().Be("$age2");
+        result1.VariableName.Should().Be("age");
+        result2.VariableName.Should().Be("age1");
+        result3.VariableName.Should().Be("age2");
     }
 }

--- a/tests/GraphQLToKarate.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/GraphQLToKarate.Tests/Extensions/StringExtensionsTests.cs
@@ -28,4 +28,24 @@ internal sealed class StringExtensionsTests
     [TestCase("", "")]
     public void FirstCharToUpperTest(string input, string expectedOutput) =>
         input.FirstCharToUpper().Should().Be(expectedOutput);
+
+    [Test]
+    [TestCase("foo", 1, " foo")]
+    [TestCase("foo", 2, "  foo")]
+    [TestCase("foo", 3, "   foo")]
+    [TestCase(
+        """
+        this is
+        a multi-line
+        string
+        """,
+        4,
+        """
+            this is
+            a multi-line
+            string
+        """
+    )]
+    public void IndentTest(string input, int indent, string expectedOutput) =>
+        input.Indent(indent).Should().Be(expectedOutput);
 }

--- a/tests/GraphQLToKarate.Tests/Features/ScenarioBuilderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Features/ScenarioBuilderTests.cs
@@ -1,0 +1,227 @@
+﻿using FluentAssertions;
+using GraphQLParser.AST;
+using GraphQLToKarate.Library.Features;
+using GraphQLToKarate.Library.Tokens;
+using GraphQLToKarate.Library.Types;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.Tests.Features;
+
+[TestFixture]
+internal sealed class ScenarioBuilderTests
+{
+    private IScenarioBuilder? _subjectUnderTest;
+
+    [SetUp]
+    public void SetUp() => _subjectUnderTest = new ScenarioBuilder();
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void ScenarioBuilder_builds_expected_scenario_string(
+        GraphQLQueryFieldType graphQLQueryFieldType,
+        string expectedScenarioString)
+    {
+        var scenarioString = _subjectUnderTest!.Build(graphQLQueryFieldType);
+
+        scenarioString.Should().Be(expectedScenarioString);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var graphQLFieldDefinition = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("todo"),
+                Type = new GraphQLNamedType
+                {
+                    Name = new GraphQLName("Todo")
+                }
+            };
+
+            yield return new TestCaseData(
+                new GraphQLQueryFieldType(graphQLFieldDefinition)
+                {
+                    Arguments = new List<GraphQLArgumentTypeBase>(),
+                    QueryString =
+                    """
+                    query TodoTest {
+                      todo {
+                        id
+                        name
+                      }
+                    }
+                    """
+                },
+                """"
+                Scenario: Perform a todo query and validate the response
+                  * text query = """
+                      query TodoTest {
+                        todo {
+                          id
+                          name
+                        }
+                      }
+                    """
+
+                  Given path "/graphql"
+                  And request { query: query, operationName: "TodoTest" }
+                  When method post
+                  Then status 200
+                  And match response.data.todo == todoSchema
+                """"
+            ).SetName("Simple query without arguments is generated as a valid scenario.");
+
+            yield return new TestCaseData(
+                new GraphQLQueryFieldType(graphQLFieldDefinition)
+                {
+                    Arguments = new List<GraphQLArgumentTypeBase>
+                    {
+                        new GraphQLNonNullArgumentType(new GraphQLArgumentType("id", "id", GraphQLToken.String)),
+                        new GraphQLArgumentType("isCompleted", "isCompleted", GraphQLToken.Boolean),
+                        new GraphQLNonNullArgumentType(
+                            new GraphQLListArgumentType(
+                                new GraphQLNonNullArgumentType(
+                                    new GraphQLArgumentType("filter", "filter", "Color")
+                                )
+                            )
+                        )
+                    },
+                    QueryString =
+                    """
+                    query TodoTest($id: String!, $isCompleted: Boolean, $filter: [Color!]!) {
+                      todo(id: $id, isCompleted: $isCompleted) {
+                        id
+                        name
+                        completed
+                        color
+                        colors(filter: $filter)
+                      }
+                    }
+                    """
+                },
+                """"
+                Scenario: Perform a todo query and validate the response
+                  * text query = """
+                      query TodoTest($id: String!, $isCompleted: Boolean, $filter: [Color!]!) {
+                        todo(id: $id, isCompleted: $isCompleted) {
+                          id
+                          name
+                          completed
+                          color
+                          colors(filter: $filter)
+                        }
+                      }
+                    """
+
+                  * text variables = """
+                      {
+                        "id": <some value>
+                        "isCompleted": <some value>
+                        "filter": <some value>
+                      }
+                    """
+
+                  Given path "/graphql"
+                  And request { query: query, operationName: "TodoTest", variables: variables }
+                  When method post
+                  Then status 200
+                  And match response.data.todo == todoSchema
+                """"
+            ).SetName("Simple query with arguments is generated as a valid scenario.");
+
+            var graphQLFieldDefinitionWithListReturn = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("todo"),
+                Type = new GraphQLListType
+                {
+                    Type = new GraphQLNamedType
+                    {
+                        Name = new GraphQLName("Todo")
+                    }
+                }
+            };
+
+            yield return new TestCaseData(
+                new GraphQLQueryFieldType(graphQLFieldDefinitionWithListReturn)
+                {
+                    Arguments = new List<GraphQLArgumentTypeBase>(),
+                    QueryString = 
+                    """
+                    query TodoTest {
+                      todo {
+                        id
+                        name
+                      }
+                    }
+                    """
+                },
+                """"
+                Scenario: Perform a todo query and validate the response
+                  * text query = """
+                      query TodoTest {
+                        todo {
+                          id
+                          name
+                        }
+                      }
+                    """
+
+                  Given path "/graphql"
+                  And request { query: query, operationName: "TodoTest" }
+                  When method post
+                  Then status 200
+                  And match each response.data.todo == todoSchema
+                """"
+            ).SetName("Simple query without arguments and list return is generated as a valid scenario.");
+
+            var graphQLFieldDefinitionWithNonNullListReturn = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("todo"),
+                Type = new GraphQLNonNullType
+                {
+                    Type = new GraphQLListType
+                    {
+                        Type = new GraphQLNamedType
+                        {
+                            Name = new GraphQLName("Todo")
+                        }
+                    }
+                }
+            };
+
+            yield return new TestCaseData(
+                new GraphQLQueryFieldType(graphQLFieldDefinitionWithNonNullListReturn)
+                {
+                    Arguments = new List<GraphQLArgumentTypeBase>(),
+                    QueryString =
+                    """
+                    query TodoTest {
+                      todo {
+                        id
+                        name
+                      }
+                    }
+                    """
+                },
+                """"
+                Scenario: Perform a todo query and validate the response
+                  * text query = """
+                      query TodoTest {
+                        todo {
+                          id
+                          name
+                        }
+                      }
+                    """
+
+                  Given path "/graphql"
+                  And request { query: query, operationName: "TodoTest" }
+                  When method post
+                  Then status 200
+                  And match each response.data.todo == todoSchema
+                """"
+            ).SetName("Simple query without arguments and non-null list return is generated as a valid scenario.");
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Simple Karate scenario generation from a given `GraphQLQueryFieldType`.
- New `Indent` string extension to allow for easy indentation of single and multi-line strings.
- Adjusted how variable names are handled to make the variables parameter generation simpler

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
