### PR TITLE
Feature File Customization

### DIFF
--- a/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
+++ b/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
@@ -33,7 +33,9 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommandSettings>
 
         var graphQLToKarateConverter = _graphQLToKarateConverterBuilder
             .Configure()
+            .WithBaseUrl(loadedCommandSettings.BaseUrl)
             .WithCustomScalarMapping(loadedCommandSettings.CustomScalarMapping)
+            .WithExcludeQueriesSetting(commandSettings.ExcludeQueries)
             .Build();
 
         var karateFeature = graphQLToKarateConverter.Convert(loadedCommandSettings.GraphQLSchema);

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
@@ -15,7 +15,7 @@ internal sealed class ConvertCommandSettings : CommandSettings
     [Description("The path and filename of the file containing the GraphQL schema to convert.")]
     public string? InputFile { get; set; }
 
-    [CommandOption("--output-filename")]
+    [CommandOption("--output-file")]
     [Description("The path and filename of the output file to write the Karate feature to.")]
     [DefaultValue(typeof(string), "graphql.feature")]
     public string? OutputFile { get; set; }
@@ -23,6 +23,14 @@ internal sealed class ConvertCommandSettings : CommandSettings
     [CommandOption("--custom-scalar-mapping")]
     [Description("The path and filename of a JSON file defining mappings of custom scalar values to karate types")]
     public string? CustomScalarMappingFile { get; set; }
+
+    [CommandOption("--exclude-queries")]
+    [DefaultValue(typeof(bool), "false")]
+    public bool ExcludeQueries { get; set; }
+
+    [CommandOption("--base-url")]
+    [DefaultValue(typeof(string), "baseUrl")]
+    public string? BaseUrl { get; set; }
 
     public override ValidationResult Validate()
     {

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
@@ -22,7 +22,9 @@ internal sealed class ConvertCommandSettingsLoader : IConvertCommandSettingsLoad
         {
             GraphQLSchema = graphQLSchema,
             CustomScalarMapping = customScalarMapping,
-            OutputFile = convertCommandSettings.OutputFile!
+            OutputFile = convertCommandSettings.OutputFile!,
+            BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl",
+            ExcludeQueries = convertCommandSettings.ExcludeQueries
         };
     }
 

--- a/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
@@ -7,4 +7,8 @@ internal sealed class LoadedConvertCommandSettings
     public required IDictionary<string, string> CustomScalarMapping { get; init; }
 
     public required string OutputFile { get; init; }
+
+    public required bool ExcludeQueries { get; init; }
+
+    public required string BaseUrl { get; init; }
 }

--- a/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using GraphQLToKarate.Library.Converters;
 using GraphQLToKarate.Library.Features;
 using GraphQLToKarate.Library.Parsers;
+using GraphQLToKarate.Library.Settings;
 
 namespace GraphQLToKarate.Library.Builders;
 
@@ -11,14 +12,32 @@ public sealed class GraphQLToKarateConverterBuilder :
 {
     private IGraphQLTypeConverter? _graphQLTypeConverter;
 
+    private bool _excludeQueriesSetting;
+
+    private string _baseUrl = "baseUrl";
+
     public IConfigurableGraphQLToKarateConverterBuilder Configure() => new GraphQLToKarateConverterBuilder();
 
-    public IConfiguredGraphQLToKarateConverterBuilder WithCustomScalarMapping(
+    public IConfigurableGraphQLToKarateConverterBuilder WithCustomScalarMapping(
         IDictionary<string, string> customScalarMapping)
     {
         _graphQLTypeConverter = customScalarMapping.Any()
             ? new GraphQLCustomScalarTypeConverter(customScalarMapping, new GraphQLTypeConverter())
             : new GraphQLTypeConverter();
+
+        return this;
+    }
+
+    public IConfigurableGraphQLToKarateConverterBuilder WithBaseUrl(string baseUrl)
+    {
+        _baseUrl = baseUrl;
+
+        return this;
+    }
+
+    public IConfigurableGraphQLToKarateConverterBuilder WithExcludeQueriesSetting(bool excludeQueriesSetting)
+    {
+        _excludeQueriesSetting = excludeQueriesSetting;
 
         return this;
     }
@@ -31,6 +50,13 @@ public sealed class GraphQLToKarateConverterBuilder :
         new GraphQLFieldDefinitionConverter(
             new GraphQLInputValueDefinitionConverterFactory()
         ),
-        new KarateFeatureBuilder(new KarateScenarioBuilder())
+        new KarateFeatureBuilder(
+            new KarateScenarioBuilder(),
+            new KarateFeatureBuilderSettings
+            {
+                BaseUrl = _baseUrl,
+                ExcludeQueries = _excludeQueriesSetting
+            }
+        )
     );
 }

--- a/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
@@ -10,6 +10,22 @@ public interface IConfigurableGraphQLToKarateConverterBuilder : IConfiguredGraph
     ///     convert to understand custom scalar types defined in the GraphQL schema.
     /// </summary>
     /// <param name="customScalarMapping">The custom scalar mapping to use.</param>
-    /// <returns>An <see cref="IConfiguredGraphQLToKarateConverterBuilder"/> with the given custom scalar mapping.</returns>
-    IConfiguredGraphQLToKarateConverterBuilder WithCustomScalarMapping(IDictionary<string, string> customScalarMapping);
+    /// <returns>An <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with the given custom scalar mapping.</returns>
+    IConfigurableGraphQLToKarateConverterBuilder WithCustomScalarMapping(IDictionary<string, string> customScalarMapping);
+
+    /// <summary>
+    ///     Configure the converter with the given <paramref name="baseUrl"/>. This allows the
+    ///     customization of the URL used in the final Karate tests.
+    /// </summary>
+    /// <param name="baseUrl">The base URL to use.</param>
+    /// <returns>An <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with the given base URL.</returns>
+    IConfigurableGraphQLToKarateConverterBuilder WithBaseUrl(string baseUrl);
+
+    /// <summary>
+    ///     Configure the converter with the given <paramref name="excludeQueriesSetting"/>. This allows the
+    ///     user to exclude queries from the final generated Karate feature, if they just want their type schemas.
+    /// </summary>
+    /// <param name="excludeQueriesSetting">Whether to exclude queries in the generated Karate feature or not.</param>
+    /// <returns>An <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with the given excluded queries setting.</returns>
+    IConfigurableGraphQLToKarateConverterBuilder WithExcludeQueriesSetting(bool excludeQueriesSetting);
 }

--- a/src/GraphQLToKarate.Library/Features/KarateFeatureBuilder.cs
+++ b/src/GraphQLToKarate.Library/Features/KarateFeatureBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using GraphQLToKarate.Library.Extensions;
+using GraphQLToKarate.Library.Settings;
 using GraphQLToKarate.Library.Tokens;
 using GraphQLToKarate.Library.Types;
 
@@ -9,8 +10,15 @@ namespace GraphQLToKarate.Library.Features;
 public sealed class KarateFeatureBuilder : IKarateFeatureBuilder
 {
     private readonly IKarateScenarioBuilder _karateScenarioBuilder;
+    private readonly KarateFeatureBuilderSettings _karateFeatureBuilderSettings;
 
-    public KarateFeatureBuilder(IKarateScenarioBuilder karateScenarioBuilder) => _karateScenarioBuilder = karateScenarioBuilder;
+    public KarateFeatureBuilder(
+        IKarateScenarioBuilder karateScenarioBuilder,
+        KarateFeatureBuilderSettings karateFeatureBuilderSettings)
+    {
+        _karateScenarioBuilder = karateScenarioBuilder;
+        _karateFeatureBuilderSettings = karateFeatureBuilderSettings;
+    }
 
     public string Build(
         IEnumerable<KarateObject> karateObjects,
@@ -20,12 +28,16 @@ public sealed class KarateFeatureBuilder : IKarateFeatureBuilder
             "Feature: Test GraphQL Endpoint with Karate",
             string.Empty,
             "Background: Base URL and Schemas",
-            "* url baseUrl".Indent(Indent.Single),
+            $"* url {_karateFeatureBuilderSettings.BaseUrl}".Indent(Indent.Single),
             string.Empty
         };
 
         lines.AddRange(BuildKarateObjects(karateObjects));
-        lines.AddRange(BuildGraphQLQueries(graphQLQueries));
+
+        if (!_karateFeatureBuilderSettings.ExcludeQueries)
+        {
+            lines.AddRange(BuildGraphQLQueries(graphQLQueries));
+        }
 
         var stringBuilder = new StringBuilder();
         stringBuilder.AppendJoin(Environment.NewLine, lines);

--- a/src/GraphQLToKarate.Library/Settings/KarateFeatureBuilderSettings.cs
+++ b/src/GraphQLToKarate.Library/Settings/KarateFeatureBuilderSettings.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace GraphQLToKarate.Library.Settings;
+
+[ExcludeFromCodeCoverage]
+public sealed class KarateFeatureBuilderSettings
+{
+    public bool ExcludeQueries { get; init; } = false;
+
+    public string BaseUrl { get; init; } = "\"https://www.my-awesome-api.com/graphql\"";
+}

--- a/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
@@ -78,7 +78,9 @@ internal sealed class ConvertCommandTests
             {
                 GraphQLSchema = schemaFileContent,
                 OutputFile = convertCommandSettings.OutputFile!,
-                CustomScalarMapping = new Dictionary<string, string>()
+                CustomScalarMapping = new Dictionary<string, string>(),
+                ExcludeQueries = convertCommandSettings.ExcludeQueries,
+                BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl"
             });
 
         // act

--- a/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
@@ -66,7 +66,9 @@ internal sealed class CommandAppConfiguratorTests
             {
                 GraphQLSchema = "some GraphQL schema",
                 OutputFile = "graphql.feature",
-                CustomScalarMapping = new Dictionary<string, string>()
+                CustomScalarMapping = new Dictionary<string, string>(),
+                ExcludeQueries = false,
+                BaseUrl = "baseUrl"
             });
 
         // act

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
@@ -70,7 +70,9 @@ internal sealed class ConvertCommandSettingsLoaderTests
         {
             InputFile = "schema.graphql",
             CustomScalarMappingFile = "config.json",
-            OutputFile = "karate.feature"
+            OutputFile = "karate.feature",
+            BaseUrl = "baseUrl",
+            ExcludeQueries = false
         };
 
         const string someCustomScalarMapping = """
@@ -103,6 +105,8 @@ internal sealed class ConvertCommandSettingsLoaderTests
         loadedConvertCommandSettings.OutputFile.Should().Be(convertCommandSettings.OutputFile);
         loadedConvertCommandSettings.GraphQLSchema.Should().Be(SomeGraphQLSchema);
         loadedConvertCommandSettings.CustomScalarMapping.Should().BeEquivalentTo(expectedCustomScalarMapping);
+        loadedConvertCommandSettings.BaseUrl.Should().Be(convertCommandSettings.BaseUrl);
+        loadedConvertCommandSettings.ExcludeQueries.Should().Be(convertCommandSettings.ExcludeQueries);
     }
 
     [Test]

--- a/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
@@ -24,6 +24,8 @@ internal sealed class GraphQLToKarateConverterBuilderTests
         var graphQLToKarateConverter = subjectUnderTest
             .Configure()
             .WithCustomScalarMapping(customScalarMapping)
+            .WithBaseUrl("https://www.builder-test.com/graphql")
+            .WithExcludeQueriesSetting(false)
             .Build();
 
         // assert


### PR DESCRIPTION
## Description

Enable generated Karate feature file customization:

- Configurable `url` to be used within the Karate test
- Users can opt to exclude queries (scenarios) from their Karate feature file, which is useful if they just want to generate Karate schemas for their GraphQL types
- Updated tests

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
