### PR TITLE
Handle Nested Union Types

### DIFF
--- a/resources/communication_schema.gql
+++ b/resources/communication_schema.gql
@@ -1,0 +1,39 @@
+type Query {
+  allUsers: [User]
+  user(id: ID!): User
+}
+
+type User {
+  id: ID!
+  name: String!
+  age: Int
+  address: Address
+  contact: Contact
+  communication: [Communication!]!
+}
+
+type Address {
+  street: String!
+  city: String!
+  country: String!
+}
+
+type Contact {
+  phoneNumber: String!
+  email: String!
+}
+
+union Communication = PhoneCall | Email
+
+type PhoneCall {
+  from: User!
+  to: User!
+  durationInMinutes: Int!
+}
+
+type Email {
+  from: User!
+  to: [User]!
+  subject: String!
+  message: String!
+}

--- a/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverter.cs
@@ -21,6 +21,8 @@ internal sealed class GraphQLTypeConverter : IGraphQLTypeConverter
             GraphQLToken.Int => KarateToken.Number,
             GraphQLToken.Float => KarateToken.Number,
             GraphQLToken.Boolean => KarateToken.Boolean,
+            { } graphqlTypeName when graphQLDocumentAdapter.IsGraphQLUnionTypeDefinition(graphqlTypeName) =>
+                KarateToken.Present,
             { } graphQLTypeName when graphQLDocumentAdapter.IsGraphQLEnumTypeDefinition(graphQLTypeName) => 
                 KarateToken.String,
             { } graphQLTypeName when graphQLDocumentAdapter.IsGraphQLTypeDefinitionWithFields(graphQLTypeName) =>

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLTypeConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLTypeConverterTests.cs
@@ -147,7 +147,9 @@ internal sealed class GraphQLTypeConverterTests
 
             const string interfaceTypeName = "TodoInterface";
 
-            var graphQLDocumentWithEnumAndCustomAndInterfaceTypeDefinition = new GraphQLDocument
+            const string unionTypeName = "TodoUnion";
+
+            var populatedGraphQLDocument = new GraphQLDocument
             {
                 Definitions = new List<ASTNode>
                 {
@@ -162,9 +164,15 @@ internal sealed class GraphQLTypeConverterTests
                     new GraphQLInterfaceTypeDefinition
                     {
                         Name = new GraphQLName(interfaceTypeName)
+                    },
+                    new GraphQLUnionTypeDefinition
+                    {
+                        Name = new GraphQLName(unionTypeName)
                     }
                 }
             };
+
+            var populatedGraphQLDocumentAdapter = new GraphQLDocumentAdapter(populatedGraphQLDocument);
 
             yield return new TestCaseData(
                 testFieldName,
@@ -172,7 +180,7 @@ internal sealed class GraphQLTypeConverterTests
                 {
                     Name = new GraphQLName(interfaceTypeName)
                 },
-                new GraphQLDocumentAdapter(graphQLDocumentWithEnumAndCustomAndInterfaceTypeDefinition),
+                new GraphQLDocumentAdapter(populatedGraphQLDocument),
                 new KarateType($"{interfaceTypeName.FirstCharToLower()}Schema", testFieldName)
             ).SetName("Custom GraphQL type is converted to custom Karate type.");
 
@@ -185,6 +193,16 @@ internal sealed class GraphQLTypeConverterTests
                 emptyGraphQLDocumentAdapter,
                 new KarateType(KarateToken.Present, testFieldName)
             ).SetName("Unknown GraphQL type is converted to present Karate type.");
+
+            yield return new TestCaseData(
+                testFieldName,
+                new GraphQLNamedType
+                {
+                    Name = new GraphQLName(unionTypeName)
+                },
+                populatedGraphQLDocumentAdapter,
+                new KarateType(KarateToken.Present, testFieldName)
+            ).SetName("Union GraphQL type as a field is converted to present Karate type.");
         }
     }
 }


### PR DESCRIPTION
## Description

Handles union types as nested fields on another type when generating Karate objects. Due to the complexity here, these are just set to `#present` on the resulting Karate object.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
