### PR TITLE
Add Multi-Schema Match Reference Feature

### DIFF
--- a/resources/multi_schema_match.feature
+++ b/resources/multi_schema_match.feature
@@ -4,7 +4,7 @@ Scenario: Validate Payload
   * def payload = 
     """
       [
-        { "id": "1", "favoriteNumber": 223 },
+        { "id": "one", "favoriteNumber": 223 },
         { "id": 2, name: "will" }
       ]
     """
@@ -26,10 +26,10 @@ Scenario: Validate Payload
     """
 
   * def isValid = 
-  """
+    """
     response => karate.match(response, schema).pass || 
                 karate.match(response, otherSchema).pass
-  """
+    """
   
   # match each
   * match each payload == "#? isValid(_)"

--- a/resources/multi_schema_match.feature
+++ b/resources/multi_schema_match.feature
@@ -1,0 +1,39 @@
+Feature: Reference Feature with Multi-Schema Validation
+
+Scenario: Validate Payload
+  * def payload = 
+    """
+      [
+        { "id": "1", "favoriteNumber": 223 },
+        { "id": 2, name: "will" }
+      ]
+    """
+
+  * def schema = 
+    """
+    { 
+      "id": "#number",
+      "name": "#string" 
+    }
+    """
+
+  * def otherSchema = 
+    """
+    { 
+      "id": "#string", 
+      "favoriteNumber": "#number" 
+    }
+    """
+
+  * def isValid = 
+  """
+    response => karate.match(response, schema).pass || 
+                karate.match(response, otherSchema).pass
+  """
+  
+  # match each
+  * match each payload == "#? isValid(_)"
+
+  # or match individually
+  * match payload[0] == "#? isValid(_)"
+  * match payload[1] == "#? isValid(_)"


### PR DESCRIPTION
## Description

Adds reference feature file that shows how to match on multiple schemas. This will be the strategy used for validating top-level union types using Karate schema validation.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
