### PR TITLE
Flexible Custom Scalar Mappings

### DIFF
--- a/src/GraphQLToKarate.CommandLine/GraphQLToKarate.CommandLine.csproj
+++ b/src/GraphQLToKarate.CommandLine/GraphQLToKarate.CommandLine.csproj
@@ -26,7 +26,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="19.1.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GraphQLToKarate.Library/GraphQLToKarate.Library.csproj
+++ b/src/GraphQLToKarate.Library/GraphQLToKarate.Library.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="GraphQL-Parser" Version="8.1.0" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="19.1.14" />
   </ItemGroup>
 
 </Project>

--- a/src/GraphQLToKarate.Library/Loaders/CustomScalarMappingLoader.cs
+++ b/src/GraphQLToKarate.Library/Loaders/CustomScalarMappingLoader.cs
@@ -1,0 +1,65 @@
+﻿using System.IO.Abstractions;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using GraphQLToKarate.Library.Tokens;
+
+namespace GraphQLToKarate.Library.Loaders;
+
+/// <inheritdoc cref="ICustomScalarMappingLoader"/>
+public sealed class CustomScalarMappingLoader : ICustomScalarMappingLoader
+{
+    private readonly Regex _regex = new(@"^([\w\s]+:[\w\s]+,\s*)+[\w\s]+:[\w\s]+$", RegexOptions.Compiled);
+    private readonly IFile _file;
+
+    public CustomScalarMappingLoader(IFile file) => _file = file;
+
+    public async Task<bool> IsFileLoadable(string filePath)
+    {
+        if (!_file.Exists(filePath))
+        {
+            return false;
+        }
+
+        var fileContent = await _file.ReadAllTextAsync(filePath);
+
+        if (string.IsNullOrWhiteSpace(fileContent))
+        {
+            return false;
+        }
+
+        if (_regex.IsMatch(fileContent))
+        {
+            return true;
+        }
+
+        try
+        {
+            var _ = JsonSerializer.Deserialize<IDictionary<string, string>>(fileContent);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public bool IsTextLoadable(string text) => _regex.IsMatch(text);
+
+    public IDictionary<string, string> LoadFromFile(string filePath)
+    {
+        var fileContent = _file.ReadAllText(filePath);
+
+        return _regex.IsMatch(fileContent)
+            ? LoadFromText(fileContent)
+            : JsonSerializer.Deserialize<IDictionary<string, string>>(fileContent)!;
+    }
+
+    public IDictionary<string, string> LoadFromText(string text) => text
+        .Split(SchemaToken.Comma, StringSplitOptions.TrimEntries)
+        .Select(customScalarMappingEntry => customScalarMappingEntry.Split(SchemaToken.Colon, StringSplitOptions.TrimEntries))
+        .ToDictionary(
+            customScalarMappingEntryParts => customScalarMappingEntryParts.First(),
+            customScalarMappingEntryParts => customScalarMappingEntryParts.Last()
+        );
+}

--- a/src/GraphQLToKarate.Library/Loaders/ICustomScalarMappingLoader.cs
+++ b/src/GraphQLToKarate.Library/Loaders/ICustomScalarMappingLoader.cs
@@ -1,0 +1,36 @@
+﻿namespace GraphQLToKarate.Library.Loaders;
+
+/// <summary>
+///     A class which can load custom scalar mappings, mapping custom scalar
+///     GraphQL types to their Karate equivalents.
+/// </summary>
+public interface ICustomScalarMappingLoader
+{
+    /// <summary>
+    ///     Returns whether the custom scalar mapping is loadable from a file.
+    /// </summary>
+    /// <param name="filePath">The file path to check.</param>
+    /// <returns>Whether or not the custom scalar mapping is loadable from the given file path.</returns>
+    Task<bool> IsFileLoadable(string filePath);
+
+    /// <summary>
+    ///     Returns whether the custom scalar mapping is loadable from a given text.
+    /// </summary>
+    /// <param name="text">The text to check.</param>
+    /// <returns>Whether or not the custom scalar mapping is loadable form the given text.</returns>
+    bool IsTextLoadable(string text);
+
+    /// <summary>
+    ///     Load the custom scalar mapping from the given file path.
+    /// </summary>
+    /// <param name="filePath">The file path to load the custom scalar mapping from.</param>
+    /// <returns>The custom scalar mapping, represented as a dictionary.</returns>
+    IDictionary<string, string> LoadFromFile(string filePath);
+
+    /// <summary>
+    ///     Load the custom scalar mapping from the given text.
+    /// </summary>
+    /// <param name="text">The text to load the custom scalar mapping from.</param>
+    /// <returns>The custom scalar mapping, represented as a dictionary.</returns>
+    IDictionary<string, string> LoadFromText(string text);
+}

--- a/src/GraphQLToKarate.Library/Tokens/SchemaToken.cs
+++ b/src/GraphQLToKarate.Library/Tokens/SchemaToken.cs
@@ -24,4 +24,6 @@ internal static class SchemaToken
     public const char CloseParen = ')';
 
     public const string TripleQuote = "\"\"\"";
+
+    public const char Colon = ':';
 }

--- a/tests/GraphQLToKarate.Tests/Loaders/CustomScalarMappingLoaderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Loaders/CustomScalarMappingLoaderTests.cs
@@ -1,0 +1,134 @@
+﻿using NUnit.Framework;
+using System.IO.Abstractions;
+using FluentAssertions;
+using GraphQLToKarate.Library.Loaders;
+using NSubstitute;
+
+namespace GraphQLToKarate.Tests.Loaders;
+
+[TestFixture]
+internal sealed class CustomScalarMappingLoaderTests
+{
+    private IFile? _mockFile;
+    private ICustomScalarMappingLoader? _subjectUnderTest;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockFile = Substitute.For<IFile>();
+        _subjectUnderTest = new CustomScalarMappingLoader(_mockFile);
+    }
+
+    private const string CustomScalarMappingAsJson = 
+        """
+        {
+            "DateTime": "string",
+            "Long": "number",
+            "URL": "string"
+        }
+        """;
+
+    private const string CustomScalarMappingAsText = " DateTime:string, Long: number,URL :string "; // messy user input with spaces
+
+    [Test]
+    public async Task IsFileLoadable_returns_false_when_file_does_not_exist()
+    {
+        // arrange
+        _mockFile!
+            .Exists(Arg.Any<string>())
+            .Returns(false);
+
+        // act
+        var isFileLoadable = await _subjectUnderTest!.IsFileLoadable("some-file-path");
+
+        // assert
+        isFileLoadable.Should().BeFalse();
+    }
+
+    [Test]
+    [TestCase("", false)]
+    [TestCase(CustomScalarMappingAsJson, true)]
+    [TestCase(CustomScalarMappingAsText, true)]
+    public async Task IsFileLoadable_returns_expected_result_based_on_file_content(
+        string fileContent, 
+        bool expectedIsFileLoadable)
+    {
+        // arrange
+        _mockFile!
+            .Exists(Arg.Any<string>())
+            .Returns(true);
+
+        _mockFile!
+            .ReadAllTextAsync(Arg.Any<string>())
+            .Returns(fileContent);
+
+        // act
+        var isFileLoadable = await _subjectUnderTest!.IsFileLoadable("some-file-path");
+
+        // assert
+        isFileLoadable.Should().Be(expectedIsFileLoadable);
+    }
+
+    [Test]
+    [TestCase("", false)]
+    [TestCase("some,random,text", false)]
+    [TestCase(CustomScalarMappingAsText, true)]
+    public void IsFileLoadable_returns_expected_result_based_on_text_content(
+        string textContent,
+        bool expectedIsTextLoadable)
+    {
+        // act
+        var result = _subjectUnderTest!.IsTextLoadable(textContent);
+
+        // assert
+        result.Should().Be(expectedIsTextLoadable);
+    }
+
+    [Test]
+    [TestCase(CustomScalarMappingAsJson)]
+    [TestCase(CustomScalarMappingAsText)]
+    public void LoadFromFile_returns_expected_result_when_file_exists_and_contains_expected_content(
+        string fileContent)
+    {
+        // arrange
+        _mockFile!
+            .Exists(Arg.Any<string>())
+            .Returns(true);
+
+        _mockFile!
+            .ReadAllText(Arg.Any<string>())
+            .Returns(fileContent);
+
+        // act
+        var customScalarMapping = _subjectUnderTest!.LoadFromFile("some-file-path");
+
+        // assert
+        customScalarMapping.Should().BeEquivalentTo(
+            new Dictionary<string, string>
+            {
+                { "DateTime", "string" },
+                { "Long", "number" },
+                { "URL", "string" }
+            }
+        );
+    }
+
+    [Test]
+    [TestCase(CustomScalarMappingAsText)]
+    public void LoadFromText_returns_expected_result_when_text_contains_expected_content(
+        string textContent)
+    {
+        // act
+        var customScalarMapping = _subjectUnderTest!.LoadFromText(textContent);
+
+        // assert
+        customScalarMapping.Should().BeEquivalentTo(
+            new Dictionary<string, string>
+            {
+                { "DateTime", "string" },
+                { "Long", "number" },
+                { "URL", "string" }
+            }
+        );
+    }
+}

--- a/tests/GraphQLToKarate.Tests/Loaders/CustomScalarMappingLoaderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Loaders/CustomScalarMappingLoaderTests.cs
@@ -47,6 +47,7 @@ internal sealed class CustomScalarMappingLoaderTests
 
     [Test]
     [TestCase("", false)]
+    [TestCase("some random text xyz {123}", false)]
     [TestCase(CustomScalarMappingAsJson, true)]
     [TestCase(CustomScalarMappingAsText, true)]
     public async Task IsFileLoadable_returns_expected_result_based_on_file_content(


### PR DESCRIPTION
## Description

Start work to make custom scalar mapping input more flexible.

Users will be allowed to input their custom scalar mappings as a file path pointing to a file containing JSON _or_ mappings that match `^([\w\s]+:[\w\s]+,\s*)+[\w\s]+:[\w\s]+$` (e.g. `Long:number, DateTime:string, URL:string`, or input the mapping string directly from the command-line prompt.

Integration coming as a follow up.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
