### PR TITLE
Allow Custom Query Name

### DIFF
--- a/resources/query_name.graphql
+++ b/resources/query_name.graphql
@@ -1,0 +1,40 @@
+type NonDefaultQuery {
+  allUsers: [User]
+  user(id: ID!): User
+  communcation: [Communication]
+}
+
+type User {
+  id: ID!
+  name: String!
+  age: Int
+  address: Address
+  contact: Contact
+  communication: [Communication!]!
+}
+
+type Address {
+  street: String!
+  city: String!
+  country: String!
+}
+
+type Contact {
+  phoneNumber: String!
+  email: String!
+}
+
+union Communication = PhoneCall | Email
+
+type PhoneCall {
+  from: User!
+  to: User!
+  durationInMinutes: Int!
+}
+
+type Email {
+  from: User!
+  to: [User]!
+  subject: String!
+  message: String!
+}

--- a/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
+++ b/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
@@ -36,6 +36,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommandSettings>
             .WithBaseUrl(loadedCommandSettings.BaseUrl)
             .WithCustomScalarMapping(loadedCommandSettings.CustomScalarMapping)
             .WithExcludeQueriesSetting(commandSettings.ExcludeQueries)
+            .WithQueryName(loadedCommandSettings.QueryName)
             .Build();
 
         var karateFeature = graphQLToKarateConverter.Convert(loadedCommandSettings.GraphQLSchema);

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
@@ -3,6 +3,7 @@ using Spectre.Console.Cli;
 using System.ComponentModel;
 using System.IO.Abstractions;
 using GraphQLToKarate.Library.Mappings;
+using GraphQLToKarate.Library.Tokens;
 
 namespace GraphQLToKarate.CommandLine.Settings;
 
@@ -40,6 +41,11 @@ internal sealed class ConvertCommandSettings : LogCommandSettings
     [Description("The base URL to be used in the Karate feature")]
     [DefaultValue(typeof(string), "baseUrl")]
     public string? BaseUrl { get; set; }
+
+    [CommandOption("--query-name")]
+    [Description("The name of the GraphQL query type")]
+    [DefaultValue(typeof(string), GraphQLToken.Query)]
+    public string? QueryName { get; set; }
 
     public override ValidationResult Validate()
     {

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
@@ -1,4 +1,5 @@
 ﻿using GraphQLToKarate.Library.Mappings;
+using GraphQLToKarate.Library.Tokens;
 using System.IO.Abstractions;
 
 namespace GraphQLToKarate.CommandLine.Settings;
@@ -29,7 +30,8 @@ internal sealed class ConvertCommandSettingsLoader : IConvertCommandSettingsLoad
             CustomScalarMapping = customScalarMapping,
             OutputFile = convertCommandSettings.OutputFile!,
             BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl",
-            ExcludeQueries = convertCommandSettings.ExcludeQueries
+            ExcludeQueries = convertCommandSettings.ExcludeQueries,
+            QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query
         };
     }
 

--- a/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
@@ -11,4 +11,6 @@ internal sealed class LoadedConvertCommandSettings
     public required bool ExcludeQueries { get; init; }
 
     public required string BaseUrl { get; init; }
+
+    public required string QueryName { get; init; }
 }

--- a/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
@@ -2,6 +2,7 @@
 using GraphQLToKarate.Library.Features;
 using GraphQLToKarate.Library.Parsers;
 using GraphQLToKarate.Library.Settings;
+using GraphQLToKarate.Library.Tokens;
 
 namespace GraphQLToKarate.Library.Builders;
 
@@ -15,6 +16,8 @@ public sealed class GraphQLToKarateConverterBuilder :
     private bool _excludeQueriesSetting;
 
     private string _baseUrl = "baseUrl";
+
+    private string _queryName = GraphQLToken.Query;
 
     public IConfigurableGraphQLToKarateConverterBuilder Configure() => new GraphQLToKarateConverterBuilder();
 
@@ -42,6 +45,13 @@ public sealed class GraphQLToKarateConverterBuilder :
         return this;
     }
 
+    public IConfigurableGraphQLToKarateConverterBuilder WithQueryName(string queryName)
+    {
+        _queryName = queryName;
+
+        return this;
+    }
+
     public IGraphQLToKarateConverter Build() => new GraphQLToKarateConverter(
         new GraphQLSchemaParser(),
         new GraphQLTypeDefinitionConverter(
@@ -57,6 +67,11 @@ public sealed class GraphQLToKarateConverterBuilder :
                 BaseUrl = _baseUrl,
                 ExcludeQueries = _excludeQueriesSetting
             }
-        )
+        ),
+        new GraphQLToKarateConverterSettings
+        {
+            ExcludeQueries = _excludeQueriesSetting,
+            QueryName = _queryName
+        }
     );
 }

--- a/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
@@ -28,4 +28,13 @@ public interface IConfigurableGraphQLToKarateConverterBuilder : IConfiguredGraph
     /// <param name="excludeQueriesSetting">Whether to exclude queries in the generated Karate feature or not.</param>
     /// <returns>An <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with the given excluded queries setting.</returns>
     IConfigurableGraphQLToKarateConverterBuilder WithExcludeQueriesSetting(bool excludeQueriesSetting);
+
+
+    /// <summary>
+    ///    Configure the converter with the given <paramref name="queryName"/>. This allows the user to specify a
+    ///    non-default query name.
+    /// </summary>
+    /// <param name="queryName">The name of the query type.</param>
+    /// <returns>An <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with the given query name.</returns>
+    IConfigurableGraphQLToKarateConverterBuilder WithQueryName(string queryName);
 }

--- a/src/GraphQLToKarate.Library/Settings/GraphQLToKarateConverterSettings.cs
+++ b/src/GraphQLToKarate.Library/Settings/GraphQLToKarateConverterSettings.cs
@@ -1,0 +1,12 @@
+﻿using GraphQLToKarate.Library.Tokens;
+using System.Diagnostics.CodeAnalysis;
+
+namespace GraphQLToKarate.Library.Settings;
+
+[ExcludeFromCodeCoverage]
+public sealed class GraphQLToKarateConverterSettings
+{
+    public bool ExcludeQueries { get; init; } = false;
+
+    public string QueryName { get; init; } = GraphQLToken.Query;
+}

--- a/src/GraphQLToKarate.Library/Tokens/GraphQLToken.cs
+++ b/src/GraphQLToKarate.Library/Tokens/GraphQLToken.cs
@@ -6,7 +6,7 @@ namespace GraphQLToKarate.Library.Tokens;
 ///     Contains tokens for each of the available GraphQL types.
 /// </summary>
 [ExcludeFromCodeCoverage]
-internal static class GraphQLToken
+public static class GraphQLToken
 {
     public const string Id = "ID";
 

--- a/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
@@ -4,6 +4,7 @@ using GraphQLToKarate.CommandLine.Settings;
 using GraphQLToKarate.Library.Builders;
 using GraphQLToKarate.Library.Converters;
 using GraphQLToKarate.Library.Mappings;
+using GraphQLToKarate.Library.Tokens;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NUnit.Framework;
@@ -78,7 +79,8 @@ internal sealed class ConvertCommandTests
                 OutputFile = convertCommandSettings.OutputFile!,
                 CustomScalarMapping = new Dictionary<string, string>(),
                 ExcludeQueries = convertCommandSettings.ExcludeQueries,
-                BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl"
+                BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl",
+                QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query
             });
 
         // act

--- a/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
@@ -4,6 +4,7 @@ using GraphQLToKarate.CommandLine.Infrastructure;
 using GraphQLToKarate.CommandLine.Settings;
 using GraphQLToKarate.Library.Builders;
 using GraphQLToKarate.Library.Mappings;
+using GraphQLToKarate.Library.Tokens;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NUnit.Framework;
@@ -70,7 +71,8 @@ internal sealed class CommandAppConfiguratorTests
                 OutputFile = "graphql.feature",
                 CustomScalarMapping = new Dictionary<string, string>(),
                 ExcludeQueries = false,
-                BaseUrl = "baseUrl"
+                BaseUrl = "baseUrl",
+                QueryName = GraphQLToken.Query
             });
 
         // act

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using NUnit.Framework;
 using System.IO.Abstractions;
 using GraphQLToKarate.Library.Mappings;
+using GraphQLToKarate.Library.Tokens;
 
 namespace GraphQLToKarate.CommandLine.Tests.Settings;
 
@@ -78,7 +79,8 @@ internal sealed class ConvertCommandSettingsLoaderTests
             CustomScalarMapping = "config.json",
             OutputFile = "karate.feature",
             BaseUrl = "baseUrl",
-            ExcludeQueries = false
+            ExcludeQueries = false,
+            QueryName = GraphQLToken.Query
         };
 
         _mockFile!
@@ -122,6 +124,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
         loadedConvertCommandSettings.CustomScalarMapping.Should().BeEquivalentTo(expectedCustomScalarMapping);
         loadedConvertCommandSettings.BaseUrl.Should().Be(convertCommandSettings.BaseUrl);
         loadedConvertCommandSettings.ExcludeQueries.Should().Be(convertCommandSettings.ExcludeQueries);
+        loadedConvertCommandSettings.QueryName.Should().Be(convertCommandSettings.QueryName);
     }
 
     [Test]

--- a/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
@@ -26,6 +26,7 @@ internal sealed class GraphQLToKarateConverterBuilderTests
             .WithCustomScalarMapping(customScalarMapping)
             .WithBaseUrl("https://www.builder-test.com/graphql")
             .WithExcludeQueriesSetting(false)
+            .WithQueryName("Hello")
             .Build();
 
         // assert

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLToKarateConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLToKarateConverterTests.cs
@@ -4,6 +4,8 @@ using GraphQLToKarate.Library.Adapters;
 using GraphQLToKarate.Library.Converters;
 using GraphQLToKarate.Library.Features;
 using GraphQLToKarate.Library.Parsers;
+using GraphQLToKarate.Library.Settings;
+using GraphQLToKarate.Library.Tokens;
 using GraphQLToKarate.Library.Types;
 using NSubstitute;
 using NUnit.Framework;
@@ -31,7 +33,8 @@ internal sealed class GraphQLToKarateConverterTests
             _mockGraphQLSchemaParser,
             _mockGraphQLTypeDefinitionConverter,
             _mockGraphQLFieldDefinitionConverter,
-            _mockKarateFeatureBuilder
+            _mockKarateFeatureBuilder,
+            new GraphQLToKarateConverterSettings()
         );
     }
 
@@ -66,7 +69,7 @@ internal sealed class GraphQLToKarateConverterTests
 
         var graphQLQuery = new GraphQLObjectTypeDefinition
         {
-            Name = new GraphQLName("Query"),
+            Name = new GraphQLName(GraphQLToken.Query),
             Fields = new GraphQLFieldsDefinition
             {
                 Items = new List<GraphQLFieldDefinition>


### PR DESCRIPTION
## Description

Allow users to provide a query name, in the case of non-default query naming.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
