### PR TITLE
Add GraphQL Type Filter

### DIFF
--- a/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
+++ b/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
@@ -37,6 +37,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommandSettings>
             .WithCustomScalarMapping(loadedCommandSettings.CustomScalarMapping)
             .WithExcludeQueriesSetting(commandSettings.ExcludeQueries)
             .WithQueryName(loadedCommandSettings.QueryName)
+            .WithTypeFilter(loadedCommandSettings.TypeFilter)
             .Build();
 
         var karateFeature = graphQLToKarateConverter.Convert(loadedCommandSettings.GraphQLSchema);

--- a/src/GraphQLToKarate.CommandLine/Infrastructure/LogLevelVerbosityConverter.cs
+++ b/src/GraphQLToKarate.CommandLine/Infrastructure/LogLevelVerbosityConverter.cs
@@ -4,6 +4,9 @@ using System.Globalization;
 
 namespace GraphQLToKarate.CommandLine.Infrastructure;
 
+/// <summary>
+///     Converts a log-level string into a <see cref="LogEventLevel"/>.
+/// </summary>
 internal sealed class LogLevelVerbosityConverter : TypeConverter
 {
     private readonly Dictionary<string, LogEventLevel> _logLevelLookup;

--- a/src/GraphQLToKarate.CommandLine/Infrastructure/TypeFilterConverter.cs
+++ b/src/GraphQLToKarate.CommandLine/Infrastructure/TypeFilterConverter.cs
@@ -1,0 +1,24 @@
+﻿using System.ComponentModel;
+using System.Globalization;
+
+namespace GraphQLToKarate.CommandLine.Infrastructure;
+
+/// <summary>
+///     Converts a comma-separated string into an ISet of strings, trimming whitespace.
+/// </summary>
+internal sealed class TypeFilterConverter : TypeConverter
+{
+    public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+    {
+        if (value is not string stringValue)
+        {
+            throw new NotSupportedException("Can't convert type filter value to type filter.");
+        }
+
+        return stringValue
+            .Split(',')
+            .Select(type => type.Trim())
+            .Where(type => !string.IsNullOrEmpty(type))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
@@ -40,12 +40,18 @@ internal sealed class ConvertCommandSettings : LogCommandSettings
     [CommandOption("--base-url")]
     [Description("The base URL to be used in the Karate feature")]
     [DefaultValue(typeof(string), "baseUrl")]
-    public string? BaseUrl { get; set; }
+    public string? BaseUrl { get; set; } = "baseUrl";
 
     [CommandOption("--query-name")]
     [Description("The name of the GraphQL query type")]
     [DefaultValue(typeof(string), GraphQLToken.Query)]
-    public string? QueryName { get; set; }
+    public string? QueryName { get; set; } = GraphQLToken.Query;
+
+    [CommandOption("--type-filter")]
+    [Description("A comma-separated list of GraphQL types to include in the Karate feature")]
+    [TypeConverter(typeof(TypeFilterConverter))]
+    [DefaultValue(typeof(string), "")]
+    public ISet<string> TypeFilter { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     public override ValidationResult Validate()
     {

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
@@ -31,7 +31,8 @@ internal sealed class ConvertCommandSettingsLoader : IConvertCommandSettingsLoad
             OutputFile = convertCommandSettings.OutputFile!,
             BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl",
             ExcludeQueries = convertCommandSettings.ExcludeQueries,
-            QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query
+            QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query,
+            TypeFilter = convertCommandSettings.TypeFilter
         };
     }
 

--- a/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
@@ -13,4 +13,6 @@ internal sealed class LoadedConvertCommandSettings
     public required string BaseUrl { get; init; }
 
     public required string QueryName { get; init; }
+
+    public required ISet<string> TypeFilter { get; init; }
 }

--- a/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
@@ -19,6 +19,8 @@ public sealed class GraphQLToKarateConverterBuilder :
 
     private string _queryName = GraphQLToken.Query;
 
+    private ISet<string> _typeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
     public IConfigurableGraphQLToKarateConverterBuilder Configure() => new GraphQLToKarateConverterBuilder();
 
     public IConfigurableGraphQLToKarateConverterBuilder WithCustomScalarMapping(
@@ -52,6 +54,13 @@ public sealed class GraphQLToKarateConverterBuilder :
         return this;
     }
 
+    public IConfigurableGraphQLToKarateConverterBuilder WithTypeFilter(ISet<string> typeFilter)
+    {
+        _typeFilter = typeFilter;
+
+        return this;
+    }
+
     public IGraphQLToKarateConverter Build() => new GraphQLToKarateConverter(
         new GraphQLSchemaParser(),
         new GraphQLTypeDefinitionConverter(
@@ -71,7 +80,8 @@ public sealed class GraphQLToKarateConverterBuilder :
         new GraphQLToKarateConverterSettings
         {
             ExcludeQueries = _excludeQueriesSetting,
-            QueryName = _queryName
+            QueryName = _queryName,
+            TypeFilter = _typeFilter
         }
     );
 }

--- a/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
@@ -37,4 +37,12 @@ public interface IConfigurableGraphQLToKarateConverterBuilder : IConfiguredGraph
     /// <param name="queryName">The name of the query type.</param>
     /// <returns>An <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with the given query name.</returns>
     IConfigurableGraphQLToKarateConverterBuilder WithQueryName(string queryName);
+
+    /// <summary>
+    ///    Configure the converter with the given <paramref name="typeFilter"/>. This allows the user to specify
+    ///    which GraphQL types to include in the output, if they'd like to filter them.
+    /// </summary>
+    /// <param name="typeFilter">The type filter to use.</param>
+    /// <returns>An <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with the given type filter.</returns>
+    IConfigurableGraphQLToKarateConverterBuilder WithTypeFilter(ISet<string> typeFilter);
 }

--- a/src/GraphQLToKarate.Library/Converters/GraphQLToKarateConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLToKarateConverter.cs
@@ -36,12 +36,28 @@ public sealed class GraphQLToKarateConverter : IGraphQLToKarateConverter
 
         var graphQLObjectTypeDefinitionsByName = graphQLDocument.Definitions
             .OfType<GraphQLObjectTypeDefinition>()
-            .Where(definition => !definition.Name.StringValue.Equals(_graphQLToKarateConverterSettings.QueryName, StringComparison.OrdinalIgnoreCase) &&
-                                 !definition.Name.StringValue.Equals(GraphQLToken.Mutation, StringComparison.OrdinalIgnoreCase))
+            .Where(definition =>
+                !definition.Name.StringValue.Equals(
+                    _graphQLToKarateConverterSettings.QueryName,
+                    StringComparison.OrdinalIgnoreCase
+                ) &&
+                !definition.Name.StringValue.Equals(
+                    GraphQLToken.Mutation,
+                    StringComparison.OrdinalIgnoreCase
+                ) &&
+                (
+                    !_graphQLToKarateConverterSettings.TypeFilter.Any() ||
+                    _graphQLToKarateConverterSettings.TypeFilter.Contains(definition.Name.StringValue)
+                )
+            )
             .ToDictionary(definition => definition.Name.StringValue);
 
         var graphQLInterfaceTypeDefinitionsByName = graphQLDocument.Definitions
             .OfType<GraphQLInterfaceTypeDefinition>()
+            .Where(definition =>
+                !_graphQLToKarateConverterSettings.TypeFilter.Any() ||
+                _graphQLToKarateConverterSettings.TypeFilter.Contains(definition.Name.StringValue)
+            )
             .ToDictionary(definition => definition.Name.StringValue);
 
         var graphQLDocumentAdapter = new GraphQLDocumentAdapter(graphQLDocument);

--- a/src/GraphQLToKarate.Library/Settings/GraphQLToKarateConverterSettings.cs
+++ b/src/GraphQLToKarate.Library/Settings/GraphQLToKarateConverterSettings.cs
@@ -9,4 +9,6 @@ public sealed class GraphQLToKarateConverterSettings
     public bool ExcludeQueries { get; init; } = false;
 
     public string QueryName { get; init; } = GraphQLToken.Query;
+
+    public ISet<string> TypeFilter { get; init; } = new HashSet<string>();
 }

--- a/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
@@ -80,7 +80,8 @@ internal sealed class ConvertCommandTests
                 CustomScalarMapping = new Dictionary<string, string>(),
                 ExcludeQueries = convertCommandSettings.ExcludeQueries,
                 BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl",
-                QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query
+                QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query,
+                TypeFilter = convertCommandSettings.TypeFilter
             });
 
         // act

--- a/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
@@ -72,7 +72,8 @@ internal sealed class CommandAppConfiguratorTests
                 CustomScalarMapping = new Dictionary<string, string>(),
                 ExcludeQueries = false,
                 BaseUrl = "baseUrl",
-                QueryName = GraphQLToken.Query
+                QueryName = GraphQLToken.Query,
+                TypeFilter = new HashSet<string>()
             });
 
         // act

--- a/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/TypeFilterConverterTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/TypeFilterConverterTests.cs
@@ -1,0 +1,71 @@
+﻿using System.ComponentModel;
+using System.Globalization;
+using FluentAssertions;
+using GraphQLToKarate.CommandLine.Infrastructure;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.CommandLine.Tests.Infrastructure;
+
+[TestFixture]
+internal sealed class TypeFilterConverterTests
+{
+    private TypeConverter? _subjectUnderTest;
+
+    [SetUp]
+    public void SetUp() => _subjectUnderTest = new TypeFilterConverter();
+
+    [Test]
+    public void ConvertFrom_should_return_expected_ISet_of_strings_when_given_valid_input()
+    {
+        // arrange
+        const string input = "  Foo, Bar, Baz  ";
+
+        // act
+        var result = _subjectUnderTest!.ConvertFrom(null, CultureInfo.InvariantCulture, input);
+
+        // assert
+        result.Should()
+            .BeEquivalentTo(new HashSet<string>(new[] { "Foo", "Bar", "Baz" }, StringComparer.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public void ConvertFrom_should_return_empty_ISet_of_strings_when_given_empty_input()
+    {
+        // arrange
+        var input = string.Empty;
+
+        // act
+        var result = _subjectUnderTest!.ConvertFrom(null, CultureInfo.InvariantCulture, input);
+
+        // assert
+        result.Should()
+            .BeEquivalentTo(new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public void ConvertFrom_should_not_return_set_containing_empty_strings_when_they_are_in_input()
+    {
+        // arrange
+        const string input = "  Foo, , Bar, Baz  ";
+
+        // act
+
+        var result = _subjectUnderTest!.ConvertFrom(null, CultureInfo.InvariantCulture, input);
+
+        // assert
+        result.Should()
+            .BeEquivalentTo(new HashSet<string>(new[] { "Foo", "Bar", "Baz" }, StringComparer.OrdinalIgnoreCase));
+    }
+
+    [Test]
+    public void ConvertFrom_should_throw_NotSupportedException_when_given_non_string_input()
+    {
+        // arrange + act
+        var act = () => _subjectUnderTest!.ConvertFrom(null, CultureInfo.InvariantCulture, 123);
+
+        // assert
+        act.Should()
+            .Throw<NotSupportedException>()
+            .WithMessage("Can't convert type filter value to type filter.");
+    }
+}

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
@@ -140,7 +140,8 @@ internal sealed class ConvertCommandSettingsLoaderTests
         {
             InputFile = "schema.graphql",
             CustomScalarMapping = null,
-            OutputFile = "karate.feature"
+            OutputFile = "karate.feature",
+            QueryName = null
         };
 
         _mockFile!
@@ -158,7 +159,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
         loadedConvertCommandSettings.CustomScalarMapping.Should().BeEquivalentTo(expectedCustomScalarMapping);
         loadedConvertCommandSettings.BaseUrl.Should().Be(convertCommandSettings.BaseUrl);
         loadedConvertCommandSettings.ExcludeQueries.Should().Be(convertCommandSettings.ExcludeQueries);
-        loadedConvertCommandSettings.QueryName.Should().Be(convertCommandSettings.QueryName);
+        loadedConvertCommandSettings.QueryName.Should().Be(GraphQLToken.Query);
         loadedConvertCommandSettings.TypeFilter.Should().BeEquivalentTo(convertCommandSettings.TypeFilter);
     }
 

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
@@ -80,7 +80,11 @@ internal sealed class ConvertCommandSettingsLoaderTests
             OutputFile = "karate.feature",
             BaseUrl = "baseUrl",
             ExcludeQueries = false,
-            QueryName = GraphQLToken.Query
+            QueryName = GraphQLToken.Query,
+            TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "Hello"
+            }
         };
 
         _mockFile!
@@ -125,6 +129,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
         loadedConvertCommandSettings.BaseUrl.Should().Be(convertCommandSettings.BaseUrl);
         loadedConvertCommandSettings.ExcludeQueries.Should().Be(convertCommandSettings.ExcludeQueries);
         loadedConvertCommandSettings.QueryName.Should().Be(convertCommandSettings.QueryName);
+        loadedConvertCommandSettings.TypeFilter.Should().BeEquivalentTo(convertCommandSettings.TypeFilter);
     }
 
     [Test]
@@ -151,6 +156,10 @@ internal sealed class ConvertCommandSettingsLoaderTests
         loadedConvertCommandSettings.OutputFile.Should().Be(convertCommandSettings.OutputFile);
         loadedConvertCommandSettings.GraphQLSchema.Should().Be(SomeGraphQLSchema);
         loadedConvertCommandSettings.CustomScalarMapping.Should().BeEquivalentTo(expectedCustomScalarMapping);
+        loadedConvertCommandSettings.BaseUrl.Should().Be(convertCommandSettings.BaseUrl);
+        loadedConvertCommandSettings.ExcludeQueries.Should().Be(convertCommandSettings.ExcludeQueries);
+        loadedConvertCommandSettings.QueryName.Should().Be(convertCommandSettings.QueryName);
+        loadedConvertCommandSettings.TypeFilter.Should().BeEquivalentTo(convertCommandSettings.TypeFilter);
     }
 
     [Test]
@@ -185,5 +194,9 @@ internal sealed class ConvertCommandSettingsLoaderTests
         loadedConvertCommandSettings.OutputFile.Should().Be(convertCommandSettings.OutputFile);
         loadedConvertCommandSettings.GraphQLSchema.Should().Be(SomeGraphQLSchema);
         loadedConvertCommandSettings.CustomScalarMapping.Should().BeEquivalentTo(expectedCustomScalarMapping);
+        loadedConvertCommandSettings.BaseUrl.Should().Be(convertCommandSettings.BaseUrl);
+        loadedConvertCommandSettings.ExcludeQueries.Should().Be(convertCommandSettings.ExcludeQueries);
+        loadedConvertCommandSettings.QueryName.Should().Be(convertCommandSettings.QueryName);
+        loadedConvertCommandSettings.TypeFilter.Should().BeEquivalentTo(convertCommandSettings.TypeFilter);
     }
 }

--- a/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
@@ -27,6 +27,7 @@ internal sealed class GraphQLToKarateConverterBuilderTests
             .WithBaseUrl("https://www.builder-test.com/graphql")
             .WithExcludeQueriesSetting(false)
             .WithQueryName("Hello")
+            .WithTypeFilter(new HashSet<string> { "Test" })
             .Build();
 
         // assert


### PR DESCRIPTION
## Description

Add the ability to filter down to a set of GraphQL types during conversion.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
