### PR TITLE
Add GraphQL Operation Filter

### DIFF
--- a/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
+++ b/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
@@ -38,6 +38,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommandSettings>
             .WithExcludeQueriesSetting(commandSettings.ExcludeQueries)
             .WithQueryName(loadedCommandSettings.QueryName)
             .WithTypeFilter(loadedCommandSettings.TypeFilter)
+            .WithOperationFilter(loadedCommandSettings.OperationFilter)
             .Build();
 
         var karateFeature = graphQLToKarateConverter.Convert(loadedCommandSettings.GraphQLSchema);

--- a/src/GraphQLToKarate.CommandLine/Infrastructure/StringToSetConverter.cs
+++ b/src/GraphQLToKarate.CommandLine/Infrastructure/StringToSetConverter.cs
@@ -6,7 +6,7 @@ namespace GraphQLToKarate.CommandLine.Infrastructure;
 /// <summary>
 ///     Converts a comma-separated string into an ISet of strings, trimming whitespace.
 /// </summary>
-internal sealed class TypeFilterConverter : TypeConverter
+internal sealed class StringToSetConverter : TypeConverter
 {
     public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
@@ -17,8 +17,8 @@ internal sealed class TypeFilterConverter : TypeConverter
 
         return stringValue
             .Split(',')
-            .Select(type => type.Trim())
-            .Where(type => !string.IsNullOrEmpty(type))
+            .Select(item => item.Trim())
+            .Where(item => !string.IsNullOrEmpty(item))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
@@ -49,9 +49,15 @@ internal sealed class ConvertCommandSettings : LogCommandSettings
 
     [CommandOption("--type-filter")]
     [Description("A comma-separated list of GraphQL types to include in the Karate feature")]
-    [TypeConverter(typeof(TypeFilterConverter))]
+    [TypeConverter(typeof(StringToSetConverter))]
     [DefaultValue(typeof(string), "")]
     public ISet<string> TypeFilter { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    [CommandOption("--operation-filter")]
+    [Description("A comma-separated list of GraphQL query operations to include in the Karate feature")]
+    [TypeConverter(typeof(StringToSetConverter))]
+    [DefaultValue(typeof(string), "")]
+    public ISet<string> OperationFilter { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     public override ValidationResult Validate()
     {

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
@@ -32,7 +32,8 @@ internal sealed class ConvertCommandSettingsLoader : IConvertCommandSettingsLoad
             BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl",
             ExcludeQueries = convertCommandSettings.ExcludeQueries,
             QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query,
-            TypeFilter = convertCommandSettings.TypeFilter
+            TypeFilter = convertCommandSettings.TypeFilter,
+            OperationFilter = convertCommandSettings.OperationFilter
         };
     }
 

--- a/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
@@ -15,4 +15,6 @@ internal sealed class LoadedConvertCommandSettings
     public required string QueryName { get; init; }
 
     public required ISet<string> TypeFilter { get; init; }
+
+    public required ISet<string> OperationFilter { get; init; }
 }

--- a/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
@@ -21,6 +21,8 @@ public sealed class GraphQLToKarateConverterBuilder :
 
     private ISet<string> _typeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+    private ISet<string> _operationFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
     public IConfigurableGraphQLToKarateConverterBuilder Configure() => new GraphQLToKarateConverterBuilder();
 
     public IConfigurableGraphQLToKarateConverterBuilder WithCustomScalarMapping(
@@ -61,6 +63,13 @@ public sealed class GraphQLToKarateConverterBuilder :
         return this;
     }
 
+    public IConfigurableGraphQLToKarateConverterBuilder WithOperationFilter(ISet<string> operationFilter)
+    {
+        _operationFilter = operationFilter;
+
+        return this;
+    }
+
     public IGraphQLToKarateConverter Build() => new GraphQLToKarateConverter(
         new GraphQLSchemaParser(),
         new GraphQLTypeDefinitionConverter(
@@ -81,7 +90,8 @@ public sealed class GraphQLToKarateConverterBuilder :
         {
             ExcludeQueries = _excludeQueriesSetting,
             QueryName = _queryName,
-            TypeFilter = _typeFilter
+            TypeFilter = _typeFilter,
+            OperationFilter = _operationFilter
         }
     );
 }

--- a/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
@@ -45,4 +45,12 @@ public interface IConfigurableGraphQLToKarateConverterBuilder : IConfiguredGraph
     /// <param name="typeFilter">The type filter to use.</param>
     /// <returns>An <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with the given type filter.</returns>
     IConfigurableGraphQLToKarateConverterBuilder WithTypeFilter(ISet<string> typeFilter);
+
+    /// <summary>
+    ///    Configure the converter with the given <paramref name="operationFilter"/>. This allows the user to specify
+    ///    which GraphQL query operations to include in the output, if they'd like to filter them.
+    /// </summary>
+    /// <param name="operationFilter">The operation filter to use.</param>
+    /// <returns>An <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with the given operation filter.</returns>
+    IConfigurableGraphQLToKarateConverterBuilder WithOperationFilter(ISet<string> operationFilter);
 }

--- a/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
@@ -9,7 +9,7 @@ namespace GraphQLToKarate.Library.Converters;
 internal sealed class GraphQLInputValueDefinitionConverter : IGraphQLInputValueDefinitionConverter
 {
     private readonly ICollection<GraphQLArgumentTypeBase> _graphQLVariableTypes = new List<GraphQLArgumentTypeBase>();
-    private readonly ISet<string> _reservedVariableNames = new HashSet<string>();
+    private readonly ISet<string> _reservedVariableNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     public GraphQLArgumentTypeBase Convert(GraphQLInputValueDefinition graphQLInputValueDefinition)
     {

--- a/src/GraphQLToKarate.Library/Settings/GraphQLToKarateConverterSettings.cs
+++ b/src/GraphQLToKarate.Library/Settings/GraphQLToKarateConverterSettings.cs
@@ -10,5 +10,7 @@ public sealed class GraphQLToKarateConverterSettings
 
     public string QueryName { get; init; } = GraphQLToken.Query;
 
-    public ISet<string> TypeFilter { get; init; } = new HashSet<string>();
+    public ISet<string> TypeFilter { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    public ISet<string> OperationFilter { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 }

--- a/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
@@ -81,7 +81,8 @@ internal sealed class ConvertCommandTests
                 ExcludeQueries = convertCommandSettings.ExcludeQueries,
                 BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl",
                 QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query,
-                TypeFilter = convertCommandSettings.TypeFilter
+                TypeFilter = convertCommandSettings.TypeFilter,
+                OperationFilter = convertCommandSettings.OperationFilter
             });
 
         // act

--- a/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
@@ -73,7 +73,8 @@ internal sealed class CommandAppConfiguratorTests
                 ExcludeQueries = false,
                 BaseUrl = "baseUrl",
                 QueryName = GraphQLToken.Query,
-                TypeFilter = new HashSet<string>()
+                TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                OperationFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             });
 
         // act

--- a/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/StringToSetConverterTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/StringToSetConverterTests.cs
@@ -7,12 +7,12 @@ using NUnit.Framework;
 namespace GraphQLToKarate.CommandLine.Tests.Infrastructure;
 
 [TestFixture]
-internal sealed class TypeFilterConverterTests
+internal sealed class StringToSetConverterTests
 {
     private TypeConverter? _subjectUnderTest;
 
     [SetUp]
-    public void SetUp() => _subjectUnderTest = new TypeFilterConverter();
+    public void SetUp() => _subjectUnderTest = new StringToSetConverter();
 
     [Test]
     public void ConvertFrom_should_return_expected_ISet_of_strings_when_given_valid_input()

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
@@ -84,6 +84,10 @@ internal sealed class ConvertCommandSettingsLoaderTests
             TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "Hello"
+            },
+            OperationFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "World"
             }
         };
 
@@ -130,6 +134,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
         loadedConvertCommandSettings.ExcludeQueries.Should().Be(convertCommandSettings.ExcludeQueries);
         loadedConvertCommandSettings.QueryName.Should().Be(convertCommandSettings.QueryName);
         loadedConvertCommandSettings.TypeFilter.Should().BeEquivalentTo(convertCommandSettings.TypeFilter);
+        loadedConvertCommandSettings.OperationFilter.Should().BeEquivalentTo(convertCommandSettings.OperationFilter);
     }
 
     [Test]
@@ -161,6 +166,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
         loadedConvertCommandSettings.ExcludeQueries.Should().Be(convertCommandSettings.ExcludeQueries);
         loadedConvertCommandSettings.QueryName.Should().Be(GraphQLToken.Query);
         loadedConvertCommandSettings.TypeFilter.Should().BeEquivalentTo(convertCommandSettings.TypeFilter);
+        loadedConvertCommandSettings.OperationFilter.Should().BeEquivalentTo(convertCommandSettings.OperationFilter);
     }
 
     [Test]
@@ -199,5 +205,6 @@ internal sealed class ConvertCommandSettingsLoaderTests
         loadedConvertCommandSettings.ExcludeQueries.Should().Be(convertCommandSettings.ExcludeQueries);
         loadedConvertCommandSettings.QueryName.Should().Be(convertCommandSettings.QueryName);
         loadedConvertCommandSettings.TypeFilter.Should().BeEquivalentTo(convertCommandSettings.TypeFilter);
+        loadedConvertCommandSettings.OperationFilter.Should().BeEquivalentTo(convertCommandSettings.OperationFilter);
     }
 }

--- a/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
@@ -28,6 +28,7 @@ internal sealed class GraphQLToKarateConverterBuilderTests
             .WithExcludeQueriesSetting(false)
             .WithQueryName("Hello")
             .WithTypeFilter(new HashSet<string> { "Test" })
+            .WithOperationFilter(new HashSet<string> { "todos" })
             .Build();
 
         // assert

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLToKarateConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLToKarateConverterTests.cs
@@ -77,7 +77,7 @@ internal sealed class GraphQLToKarateConverterTests
         {
             QueryName = GraphQLToken.Query,
             ExcludeQueries = false,
-            TypeFilter = new HashSet<string>()
+            TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         };
 
         var subjectUnderTest = new GraphQLToKarateConverter(
@@ -307,6 +307,178 @@ internal sealed class GraphQLToKarateConverterTests
             );
     }
 
+    [Test]
+    public void Convert_only_invokes_GraphQLFieldDefinitionConverter_for_Todo_query_in_OperationFilter_setting()
+    {
+        // arrange
+        _mockGraphQLSchemaParser!
+            .Parse(SomeSchemaString)
+            .Returns(TestGraphQLDocument);
+
+        _mockGraphQLTypeDefinitionConverter!
+            .Convert(Arg.Any<GraphQLObjectTypeDefinition>(), Arg.Any<GraphQLDocumentAdapter>())
+            .Returns(TestKarateObject);
+
+        _mockGraphQLTypeDefinitionConverter!
+            .Convert(Arg.Any<GraphQLInterfaceTypeDefinition>(), Arg.Any<GraphQLDocumentAdapter>())
+            .Returns(OtherTestKarateObject);
+
+        _mockGraphQLFieldDefinitionConverter!
+            .Convert(
+                Arg.Is<GraphQLFieldDefinition>(
+                    arg => arg.Name.StringValue == TodoQueryFieldDefinition.Name.StringValue
+                ),
+                Arg.Any<GraphQLDocumentAdapter>()
+            )
+            .Returns(TodoQueryFieldType);
+
+        _mockKarateFeatureBuilder!
+            .Build(
+                Arg.Any<IEnumerable<KarateObject>>(),
+                Arg.Any<IEnumerable<GraphQLQueryFieldType>>(),
+                Arg.Any<IGraphQLDocumentAdapter>()
+            )
+            .Returns(ExpectedKarateFeature)
+            .AndDoes(ForceEnumerationOfMockedEnumerables);
+
+        var settings = new GraphQLToKarateConverterSettings
+        {
+            QueryName = GraphQLToken.Query,
+            TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            OperationFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                TodoQueryFieldDefinition.Name.StringValue
+            },
+            ExcludeQueries = false
+        };
+
+        var subjectUnderTest = new GraphQLToKarateConverter(
+            _mockGraphQLSchemaParser,
+            _mockGraphQLTypeDefinitionConverter,
+            _mockGraphQLFieldDefinitionConverter,
+            _mockKarateFeatureBuilder,
+            settings
+        );
+
+        // act
+        var karateFeature = subjectUnderTest.Convert(SomeSchemaString);
+
+        // assert
+        karateFeature.Should().Be(ExpectedKarateFeature);
+
+        _mockGraphQLSchemaParser
+            .Received(1)
+            .Parse(SomeSchemaString);
+
+        _mockGraphQLTypeDefinitionConverter
+            .Received(1)
+            .Convert(GraphQLObjectTypeDefinition, Arg.Any<GraphQLDocumentAdapter>());
+
+        _mockGraphQLTypeDefinitionConverter
+            .Received(1)
+            .Convert(GraphQLInterfaceTypeDefinition, Arg.Any<GraphQLDocumentAdapter>());
+
+        _mockGraphQLFieldDefinitionConverter
+            .Received(1)
+            .Convert(TodoQueryFieldDefinition, Arg.Any<GraphQLDocumentAdapter>());
+
+        _mockGraphQLFieldDefinitionConverter
+            .DidNotReceive()
+            .Convert(TodosQueryFieldDefinition, Arg.Any<GraphQLDocumentAdapter>());
+
+        _mockKarateFeatureBuilder
+            .Received(1)
+            .Build(
+                Arg.Is<IEnumerable<KarateObject>>(arg => arg.Count() == 2),
+                Arg.Is<IEnumerable<GraphQLQueryFieldType>>(arg => arg.Count() == 1),
+                Arg.Any<IGraphQLDocumentAdapter>()
+            );
+    }
+
+    [Test]
+    public void Convert_only_invokes_GraphQLFieldDefinitionConverter_for_Todos_query_in_OperationFilter_setting()
+    {
+        // arrange
+        _mockGraphQLSchemaParser!
+            .Parse(SomeSchemaString)
+            .Returns(TestGraphQLDocument);
+
+        _mockGraphQLTypeDefinitionConverter!
+            .Convert(Arg.Any<GraphQLObjectTypeDefinition>(), Arg.Any<GraphQLDocumentAdapter>())
+            .Returns(TestKarateObject);
+
+        _mockGraphQLTypeDefinitionConverter!
+            .Convert(Arg.Any<GraphQLInterfaceTypeDefinition>(), Arg.Any<GraphQLDocumentAdapter>())
+            .Returns(OtherTestKarateObject);
+
+        _mockGraphQLFieldDefinitionConverter!
+            .Convert(
+                Arg.Is<GraphQLFieldDefinition>(
+                    arg => arg.Name.StringValue == TodosQueryFieldDefinition.Name.StringValue
+                ),
+                Arg.Any<GraphQLDocumentAdapter>()
+            )
+            .Returns(TodosQueryFieldType);
+
+        _mockKarateFeatureBuilder!
+            .Build(
+                Arg.Any<IEnumerable<KarateObject>>(),
+                Arg.Any<IEnumerable<GraphQLQueryFieldType>>(),
+                Arg.Any<IGraphQLDocumentAdapter>()
+            )
+            .Returns(ExpectedKarateFeature)
+            .AndDoes(ForceEnumerationOfMockedEnumerables);
+
+        var settings = new GraphQLToKarateConverterSettings
+        {
+            QueryName = GraphQLToken.Query,
+            TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            OperationFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                TodosQueryFieldDefinition.Name.StringValue
+            },
+            ExcludeQueries = false
+        };
+
+        var subjectUnderTest = new GraphQLToKarateConverter(
+            _mockGraphQLSchemaParser,
+            _mockGraphQLTypeDefinitionConverter,
+            _mockGraphQLFieldDefinitionConverter,
+            _mockKarateFeatureBuilder,
+            settings
+        );
+
+        // act
+        var karateFeature = subjectUnderTest.Convert(SomeSchemaString);
+
+        // assert
+        karateFeature.Should().Be(ExpectedKarateFeature);
+
+        _mockGraphQLSchemaParser
+            .Received(1)
+            .Parse(SomeSchemaString);
+
+        _mockGraphQLTypeDefinitionConverter
+            .Received(1)
+            .Convert(GraphQLObjectTypeDefinition, Arg.Any<GraphQLDocumentAdapter>());
+
+        _mockGraphQLTypeDefinitionConverter
+            .Received(1)
+            .Convert(GraphQLInterfaceTypeDefinition, Arg.Any<GraphQLDocumentAdapter>());
+
+        _mockGraphQLFieldDefinitionConverter
+            .DidNotReceive()
+            .Convert(TodoQueryFieldDefinition, Arg.Any<GraphQLDocumentAdapter>());
+
+        _mockKarateFeatureBuilder
+            .Received(1)
+            .Build(
+                Arg.Is<IEnumerable<KarateObject>>(arg => arg.Count() == 2),
+                Arg.Is<IEnumerable<GraphQLQueryFieldType>>(arg => arg.Count() == 1),
+                Arg.Any<IGraphQLDocumentAdapter>()
+            );
+    }
+
     private static void ForceEnumerationOfMockedEnumerables(CallInfo callInfo)
     {
         var karateObjects = callInfo.ArgAt<IEnumerable<KarateObject>>(0);
@@ -329,7 +501,8 @@ internal sealed class GraphQLToKarateConverterTests
 
     private static readonly KarateObject TestKarateObject = new("TestKarateObject", new List<KarateTypeBase>());
 
-    private static readonly KarateObject OtherTestKarateObject = new("OtherTestKarateObject", new List<KarateTypeBase>());
+    private static readonly KarateObject OtherTestKarateObject =
+        new("OtherTestKarateObject", new List<KarateTypeBase>());
 
     private static readonly GraphQLFieldDefinition TodoQueryFieldDefinition = new()
     {


### PR DESCRIPTION
## Description

Add the ability to filter down to a set of GraphQL operations during conversion.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
