### PR TITLE
Refactors + Cleanup

### DIFF
--- a/src/GraphQLToKarate.Library/Adapters/GraphQLDocumentAdapter.cs
+++ b/src/GraphQLToKarate.Library/Adapters/GraphQLDocumentAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using GraphQLParser.AST;
+using GraphQLToKarate.Library.Extensions;
 
 namespace GraphQLToKarate.Library.Adapters;
 
@@ -24,25 +25,25 @@ public sealed class GraphQLDocumentAdapter : IGraphQLDocumentAdapter
             {
                 case GraphQLEnumTypeDefinition graphQLEnumTypeDefinition:
                     _graphQLEnumTypeDefinitionsByName.Add(
-                        graphQLEnumTypeDefinition.Name.StringValue,
+                        graphQLEnumTypeDefinition.NameValue(),
                         graphQLEnumTypeDefinition
                     );
                     break;
                 case GraphQLObjectTypeDefinition graphQLObjectTypeDefinition:
                     _graphQLTypeDefinitionsWithFieldsByName.Add(
-                        graphQLObjectTypeDefinition.Name.StringValue,
+                        graphQLObjectTypeDefinition.NameValue(),
                         graphQLObjectTypeDefinition
                     );
                     break;
                 case GraphQLInterfaceTypeDefinition graphQLInterfaceTypeDefinition:
                     _graphQLTypeDefinitionsWithFieldsByName.Add(
-                        graphQLInterfaceTypeDefinition.Name.StringValue,
+                        graphQLInterfaceTypeDefinition.NameValue(),
                         graphQLInterfaceTypeDefinition
                     );
                     break;
                 case GraphQLUnionTypeDefinition graphQLUnionTypeDefinition:
                     _graphQLUnionTypeDefinitionsByName.Add(
-                        graphQLUnionTypeDefinition.Name.StringValue,
+                        graphQLUnionTypeDefinition.NameValue(),
                         graphQLUnionTypeDefinition
                     );
                     break;

--- a/src/GraphQLToKarate.Library/Converters/GraphQLFieldDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLFieldDefinitionConverter.cs
@@ -50,8 +50,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
 
         var stringBuilder = new StringBuilder();
 
-        stringBuilder.Append(new string(SchemaToken.Space, indentationLevel + 2));
-        stringBuilder.Append(graphQLFieldDefinition.Name.StringValue);
+        stringBuilder.Append(graphQLFieldDefinition.NameValue().Indent(indentationLevel + 2));
 
         HandleArguments(graphQLFieldDefinition, graphQLInputValueDefinitionConverter, stringBuilder);
 
@@ -75,8 +74,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
             indentationLevel
         );
 
-        stringBuilder.Append(new string(SchemaToken.Space, indentationLevel + 2));
-        stringBuilder.AppendLine($"{SchemaToken.CloseBrace}");
+        stringBuilder.AppendLine($"{SchemaToken.CloseBrace}".Indent(indentationLevel + 2));
 
         if (indentationLevel == 0)
         {
@@ -135,8 +133,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
         {
             var graphQLTypeName = graphQLNamedType.GetTypeName();
 
-            stringBuilder.Append(new string(SchemaToken.Space, indentationLevel + 4));
-            stringBuilder.AppendLine($"... on {graphQLTypeName} {SchemaToken.OpenBrace}");
+            stringBuilder.AppendLine($"... on {graphQLTypeName} {SchemaToken.OpenBrace}".Indent(indentationLevel + 4));
 
             var innerUnionTypeDefinitionWithFields = graphQLDocumentAdapter.GetGraphQLTypeDefinitionWithFields(
                 graphQLTypeName
@@ -152,8 +149,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
                 indentationLevel + 2
             );
 
-            stringBuilder.Append(new string(SchemaToken.Space, indentationLevel + 4));
-            stringBuilder.AppendLine($"{SchemaToken.CloseBrace}");
+            stringBuilder.AppendLine($"{SchemaToken.CloseBrace}".Indent(indentationLevel + 4));
         }
     }
 
@@ -223,8 +219,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
         }
         else
         {
-            stringBuilder.Append(new string(SchemaToken.Space, indentationLevel + 4));
-            stringBuilder.Append(graphQLFieldDefinition.Name.StringValue);
+            stringBuilder.Append(graphQLFieldDefinition.NameValue().Indent(indentationLevel + 4));
 
             HandleArguments(graphQLFieldDefinition, graphQLInputValueDefinitionConverter, stringBuilder);
 
@@ -262,7 +257,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
     {
         var operationStringBuilder = new StringBuilder();
 
-        operationStringBuilder.Append($"query {graphQLQueryFieldDefinition.Name.StringValue.FirstCharToUpper()}Test");
+        operationStringBuilder.Append($"query {graphQLQueryFieldDefinition.NameValue().FirstCharToUpper()}Test");
 
         var graphQLArgumentTypes = graphQLInputValueDefinitionConverter.GetAllConverted();
 

--- a/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
@@ -13,7 +13,7 @@ internal sealed class GraphQLInputValueDefinitionConverter : IGraphQLInputValueD
 
     public GraphQLArgumentTypeBase Convert(GraphQLInputValueDefinition graphQLInputValueDefinition)
     {
-        var graphQLArgumentName = graphQLInputValueDefinition.Name.StringValue;
+        var graphQLArgumentName = graphQLInputValueDefinition.NameValue();
         var graphQLVariableName = GetNonReservedVariableName(graphQLArgumentName);
         var graphQLVariableTypeName = Convert(graphQLInputValueDefinition, graphQLArgumentName, graphQLVariableName);
 
@@ -69,16 +69,14 @@ internal sealed class GraphQLInputValueDefinitionConverter : IGraphQLInputValueD
     private static GraphQLArgumentTypeBase GetGraphQLInnerVariableType(
         GraphQLType graphQLType,
         string graphQLArgumentName,
-        string graphQLVariableName)
+        string graphQLVariableName
+    ) => graphQLType switch
     {
-        return graphQLType switch
-        {
-            GraphQLListType => GetGraphQLListVariableType(graphQLType, graphQLArgumentName, graphQLVariableName),
-            GraphQLNamedType => GetGraphQLNamedVariableType(graphQLType, graphQLArgumentName, graphQLVariableName),
-            GraphQLNonNullType => GetGraphQLNonNullVariableType(graphQLType, graphQLArgumentName, graphQLVariableName),
-            _ => throw new InvalidGraphQLTypeException()
-        };
-    }
+        GraphQLListType => GetGraphQLListVariableType(graphQLType, graphQLArgumentName, graphQLVariableName),
+        GraphQLNamedType => GetGraphQLNamedVariableType(graphQLType, graphQLArgumentName, graphQLVariableName),
+        GraphQLNonNullType => GetGraphQLNonNullVariableType(graphQLType, graphQLArgumentName, graphQLVariableName),
+        _ => throw new InvalidGraphQLTypeException()
+    };
 
     private string GetNonReservedVariableName(string inputValueDefinitionName, int nameIndex = 1)
     {

--- a/src/GraphQLToKarate.Library/Converters/GraphQLScalarToExampleValueConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLScalarToExampleValueConverter.cs
@@ -51,6 +51,6 @@ internal sealed class GraphQLScalarToExampleValueConverter : IGraphQLToExampleVa
 
         var index = _random.Next(0, graphQLEnumTypeDefinition.Values.Count);
 
-        return graphQLEnumTypeDefinition.Values[index].Name.StringValue;
+        return graphQLEnumTypeDefinition.Values[index].NameValue();
     }
 }

--- a/src/GraphQLToKarate.Library/Converters/GraphQLTypeDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLTypeDefinitionConverter.cs
@@ -1,6 +1,7 @@
 ﻿using GraphQLParser.AST;
 using GraphQLToKarate.Library.Adapters;
 using GraphQLToKarate.Library.Exceptions;
+using GraphQLToKarate.Library.Extensions;
 using GraphQLToKarate.Library.Types;
 
 namespace GraphQLToKarate.Library.Converters;
@@ -19,7 +20,7 @@ public sealed class GraphQLTypeDefinitionConverter : IGraphQLTypeDefinitionConve
     {
         if (graphQLTypeDefinition.Fields is null)
         {
-            return new KarateObject(graphQLTypeDefinition.Name.StringValue, new List<KarateTypeBase>());
+            return new KarateObject(graphQLTypeDefinition.NameValue(), new List<KarateTypeBase>());
         }
 
         var karateTypes =
@@ -32,11 +33,11 @@ public sealed class GraphQLTypeDefinitionConverter : IGraphQLTypeDefinitionConve
                 _ => throw new InvalidGraphQLTypeException()
             }
             select converter.Convert(
-                graphQLFieldDefinition.Name.StringValue,
+                graphQLFieldDefinition.NameValue(),
                 graphQLFieldDefinition.Type,
                 graphQLDocumentAdapter
             );
 
-        return new KarateObject(graphQLTypeDefinition.Name.StringValue, karateTypes.ToList());
+        return new KarateObject(graphQLTypeDefinition.NameValue(), karateTypes.ToList());
     }
 }

--- a/src/GraphQLToKarate.Library/Extensions/CollectionExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/CollectionExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace GraphQLToKarate.Library.Extensions;
+
+/// <summary>
+///     A home for extension methods on <see cref="ICollection{T}"/>.
+/// </summary>
+internal static class CollectionExtensions
+{
+    /// <summary>
+    ///    Returns true if the collection is empty or contains the given item. This method is useful
+    ///    for optional "filter" type operations, where collection to filter with would be empty if
+    ///    the user didn't specify any filters.
+    /// </summary>
+    /// <typeparam name="T">The type of the collection.</typeparam>
+    /// <param name="collection">The collection to check.</param>
+    /// <param name="item">The item to check for.</param>
+    /// <returns>Whether the collection is empty or contains the given item.</returns>
+    public static bool NoneOrContains<T>(this ICollection<T> collection, T item) =>
+        !collection.Any() || collection.Contains(item);
+}

--- a/src/GraphQLToKarate.Library/Extensions/GraphQLTypeExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/GraphQLTypeExtensions.cs
@@ -23,10 +23,17 @@ internal static class GraphQLTypeExtensions
                     graphQLType = graphQLListType.Type;
                     continue;
                 case GraphQLNamedType namedType:
-                    return namedType.Name.StringValue;
+                    return namedType.NameValue();
                 default:
                     throw new InvalidGraphQLTypeException();
             }
         }
     }
+
+    /// <summary>
+    ///     Convenience method for accessing named node string values.
+    /// </summary>
+    /// <param name="namedNode">The node to retrieve the name value of</param>
+    /// <returns>The string value of the node's name</returns>
+    public static string NameValue(this INamedNode namedNode) => namedNode.Name.StringValue;
 }

--- a/src/GraphQLToKarate.Library/Extensions/StringExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/StringExtensions.cs
@@ -45,6 +45,8 @@ internal static class StringExtensions
 
     /// <summary>
     ///     Indents a <paramref name="source"/> string (including multi-line strings) by the specified <see cref="indent"/> amount.
+    ///
+    ///     This is different than <see cref="string.PadLeft(int)"/> in that it properly indents strings that span multiple lines.
     /// </summary>
     /// <param name="source">The string to manipulate.</param>
     /// <param name="indent">The amount to indent the string.</param>

--- a/src/GraphQLToKarate.Library/Features/KarateScenarioBuilder.cs
+++ b/src/GraphQLToKarate.Library/Features/KarateScenarioBuilder.cs
@@ -76,7 +76,7 @@ public sealed class KarateScenarioBuilder : IKarateScenarioBuilder
         foreach (var graphQLUnionType in graphQLUnionTypeDefinition.Types!)
         {
             stringBuilder.AppendLine(
-                $"karate.match(response, {graphQLUnionType.Name.StringValue.FirstCharToLower()}Schema).pass ||".Indent(Indent.Triple)
+                $"karate.match(response, {graphQLUnionType.NameValue().FirstCharToLower()}Schema).pass ||".Indent(Indent.Triple)
             );
         }
 

--- a/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
+++ b/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
@@ -7,7 +7,7 @@ public sealed class GraphQLQueryFieldType
 {
     private readonly GraphQLFieldDefinition _queryField;
 
-    public string Name => _queryField.Name.StringValue;
+    public string Name => _queryField.NameValue();
 
     public string OperationName => $"{Name.FirstCharToUpper()}Test";
 

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLScalarToExampleValueConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLScalarToExampleValueConverterTests.cs
@@ -3,6 +3,7 @@ using GraphQLParser.AST;
 using GraphQLToKarate.Library.Adapters;
 using GraphQLToKarate.Library.Converters;
 using GraphQLToKarate.Library.Exceptions;
+using GraphQLToKarate.Library.Extensions;
 using GraphQLToKarate.Library.Tokens;
 using NSubstitute;
 using NUnit.Framework;
@@ -104,11 +105,11 @@ internal sealed class GraphQLScalarToExampleValueConverterTests
         };
 
         _mockGraphQLDocumentAdapter!
-            .IsGraphQLEnumTypeDefinition(graphQLType.Name.StringValue)
+            .IsGraphQLEnumTypeDefinition(graphQLType.NameValue())
             .Returns(true);
 
         _mockGraphQLDocumentAdapter
-            .GetGraphQLEnumTypeDefinition(graphQLType.Name.StringValue)
+            .GetGraphQLEnumTypeDefinition(graphQLType.NameValue())
             .Returns(graphQLEnumType);
 
         // act
@@ -128,11 +129,11 @@ internal sealed class GraphQLScalarToExampleValueConverterTests
         };
 
         _mockGraphQLDocumentAdapter!
-            .IsGraphQLEnumTypeDefinition(graphQLType.Name.StringValue)
+            .IsGraphQLEnumTypeDefinition(graphQLType.NameValue())
             .Returns(true);
 
         _mockGraphQLDocumentAdapter
-            .GetGraphQLEnumTypeDefinition(graphQLType.Name.StringValue)
+            .GetGraphQLEnumTypeDefinition(graphQLType.NameValue())
             .Returns((GraphQLEnumTypeDefinition?) null);
 
         // act
@@ -158,11 +159,11 @@ internal sealed class GraphQLScalarToExampleValueConverterTests
         };
 
         _mockGraphQLDocumentAdapter!
-            .IsGraphQLEnumTypeDefinition(graphQLType.Name.StringValue)
+            .IsGraphQLEnumTypeDefinition(graphQLType.NameValue())
             .Returns(true);
 
         _mockGraphQLDocumentAdapter
-            .GetGraphQLEnumTypeDefinition(graphQLType.Name.StringValue)
+            .GetGraphQLEnumTypeDefinition(graphQLType.NameValue())
             .Returns(graphQLEnumType);
 
         // act
@@ -182,7 +183,7 @@ internal sealed class GraphQLScalarToExampleValueConverterTests
         };
 
         _mockGraphQLDocumentAdapter!
-            .IsGraphQLEnumTypeDefinition(graphQLType.Name.StringValue)
+            .IsGraphQLEnumTypeDefinition(graphQLType.NameValue())
             .Returns(false);
 
         // act

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLToKarateConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLToKarateConverterTests.cs
@@ -2,6 +2,7 @@
 using GraphQLParser.AST;
 using GraphQLToKarate.Library.Adapters;
 using GraphQLToKarate.Library.Converters;
+using GraphQLToKarate.Library.Extensions;
 using GraphQLToKarate.Library.Features;
 using GraphQLToKarate.Library.Parsers;
 using GraphQLToKarate.Library.Settings;
@@ -49,7 +50,7 @@ internal sealed class GraphQLToKarateConverterTests
         _mockGraphQLFieldDefinitionConverter!
             .Convert(
                 Arg.Is<GraphQLFieldDefinition>(
-                    arg => arg.Name.StringValue == TodoQueryFieldDefinition.Name.StringValue
+                    arg => arg.NameValue() == TodoQueryFieldDefinition.NameValue()
                 ),
                 Arg.Any<GraphQLDocumentAdapter>()
             )
@@ -58,7 +59,7 @@ internal sealed class GraphQLToKarateConverterTests
         _mockGraphQLFieldDefinitionConverter!
             .Convert(
                 Arg.Is<GraphQLFieldDefinition>(
-                    arg => arg.Name.StringValue == TodosQueryFieldDefinition.Name.StringValue
+                    arg => arg.NameValue() == TodosQueryFieldDefinition.NameValue()
                 ),
                 Arg.Any<GraphQLDocumentAdapter>()
             )
@@ -138,7 +139,7 @@ internal sealed class GraphQLToKarateConverterTests
         _mockGraphQLFieldDefinitionConverter!
             .Convert(
                 Arg.Is<GraphQLFieldDefinition>(
-                    arg => arg.Name.StringValue == TodoQueryFieldDefinition.Name.StringValue
+                    arg => arg.NameValue() == TodoQueryFieldDefinition.NameValue()
                 ),
                 Arg.Any<GraphQLDocumentAdapter>()
             )
@@ -147,7 +148,7 @@ internal sealed class GraphQLToKarateConverterTests
         _mockGraphQLFieldDefinitionConverter!
             .Convert(
                 Arg.Is<GraphQLFieldDefinition>(
-                    arg => arg.Name.StringValue == TodosQueryFieldDefinition.Name.StringValue
+                    arg => arg.NameValue() == TodosQueryFieldDefinition.NameValue()
                 ),
                 Arg.Any<GraphQLDocumentAdapter>()
             )
@@ -168,7 +169,7 @@ internal sealed class GraphQLToKarateConverterTests
             QueryName = GraphQLToken.Query,
             TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
-                GraphQLObjectTypeDefinition.Name.StringValue
+                GraphQLObjectTypeDefinition.NameValue()
             }
         };
 
@@ -230,7 +231,7 @@ internal sealed class GraphQLToKarateConverterTests
         _mockGraphQLFieldDefinitionConverter!
             .Convert(
                 Arg.Is<GraphQLFieldDefinition>(
-                    arg => arg.Name.StringValue == TodoQueryFieldDefinition.Name.StringValue
+                    arg => arg.NameValue() == TodoQueryFieldDefinition.NameValue()
                 ),
                 Arg.Any<GraphQLDocumentAdapter>()
             )
@@ -239,7 +240,7 @@ internal sealed class GraphQLToKarateConverterTests
         _mockGraphQLFieldDefinitionConverter!
             .Convert(
                 Arg.Is<GraphQLFieldDefinition>(
-                    arg => arg.Name.StringValue == TodosQueryFieldDefinition.Name.StringValue
+                    arg => arg.NameValue() == TodosQueryFieldDefinition.NameValue()
                 ),
                 Arg.Any<GraphQLDocumentAdapter>()
             )
@@ -259,7 +260,7 @@ internal sealed class GraphQLToKarateConverterTests
             QueryName = GraphQLToken.Query,
             TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
-                GraphQLInterfaceTypeDefinition.Name.StringValue
+                GraphQLInterfaceTypeDefinition.NameValue()
             },
             ExcludeQueries = false
         };
@@ -326,7 +327,7 @@ internal sealed class GraphQLToKarateConverterTests
         _mockGraphQLFieldDefinitionConverter!
             .Convert(
                 Arg.Is<GraphQLFieldDefinition>(
-                    arg => arg.Name.StringValue == TodoQueryFieldDefinition.Name.StringValue
+                    arg => arg.NameValue() == TodoQueryFieldDefinition.NameValue()
                 ),
                 Arg.Any<GraphQLDocumentAdapter>()
             )
@@ -347,7 +348,7 @@ internal sealed class GraphQLToKarateConverterTests
             TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase),
             OperationFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
-                TodoQueryFieldDefinition.Name.StringValue
+                TodoQueryFieldDefinition.NameValue()
             },
             ExcludeQueries = false
         };
@@ -414,7 +415,7 @@ internal sealed class GraphQLToKarateConverterTests
         _mockGraphQLFieldDefinitionConverter!
             .Convert(
                 Arg.Is<GraphQLFieldDefinition>(
-                    arg => arg.Name.StringValue == TodosQueryFieldDefinition.Name.StringValue
+                    arg => arg.NameValue() == TodosQueryFieldDefinition.NameValue()
                 ),
                 Arg.Any<GraphQLDocumentAdapter>()
             )
@@ -435,7 +436,7 @@ internal sealed class GraphQLToKarateConverterTests
             TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase),
             OperationFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
-                TodosQueryFieldDefinition.Name.StringValue
+                TodosQueryFieldDefinition.NameValue()
             },
             ExcludeQueries = false
         };

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLTypeDefinitionConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLTypeDefinitionConverterTests.cs
@@ -2,6 +2,7 @@
 using GraphQLParser.AST;
 using GraphQLToKarate.Library.Adapters;
 using GraphQLToKarate.Library.Converters;
+using GraphQLToKarate.Library.Extensions;
 using GraphQLToKarate.Library.Tokens;
 using GraphQLToKarate.Library.Types;
 using NSubstitute;
@@ -70,7 +71,7 @@ internal sealed class GraphQlTypeDefinitionConverterTests
         }
 
         var expectedKarateObject = new KarateObject(
-            graphQLObjectTypeDefinition.Name.StringValue,
+            graphQLObjectTypeDefinition.NameValue(),
             karateTypesByFieldDefinitionName.Values.ToList()
         );
 
@@ -107,29 +108,29 @@ internal sealed class GraphQlTypeDefinitionConverterTests
                 new Dictionary<string, KarateTypeBase>
                 {
                     {
-                        NonNullGraphQLFieldDefinition.Name.StringValue,
+                        NonNullGraphQLFieldDefinition.NameValue(),
                         new KarateNonNullType(
                             new KarateType(
                                 KarateToken.Number,
-                                NonNullGraphQLFieldDefinition.Name.StringValue
+                                NonNullGraphQLFieldDefinition.NameValue()
                             )
                         )
                     },
                     {
-                        NullGraphQLFieldDefinition.Name.StringValue,
+                        NullGraphQLFieldDefinition.NameValue(),
                         new KarateNullType(
                             new KarateType(
                                 KarateToken.String,
-                                NullGraphQLFieldDefinition.Name.StringValue
+                                NullGraphQLFieldDefinition.NameValue()
                             )
                         )
                     },
                     {
-                        ListGraphQLFieldDefinition.Name.StringValue,
+                        ListGraphQLFieldDefinition.NameValue(),
                         new KarateListType(
                             new KarateType(
                                 KarateToken.Boolean,
-                                ListGraphQLFieldDefinition.Name.StringValue
+                                ListGraphQLFieldDefinition.NameValue()
                             )
                         )
                     }

--- a/tests/GraphQLToKarate.Tests/Extensions/CollectionExtensionTests.cs
+++ b/tests/GraphQLToKarate.Tests/Extensions/CollectionExtensionTests.cs
@@ -1,0 +1,32 @@
+﻿using FluentAssertions;
+using GraphQLToKarate.Library.Extensions;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.Tests.Extensions;
+
+[TestFixture]
+public class CollectionExtensionsTests
+{
+    [Test, TestCaseSource(nameof(TestCases))]
+    public void NoneOrContains_should_return_expected_result(
+        ICollection<int> collection, 
+        int item, 
+        bool expected)
+    {
+        // Act
+        var actual = collection.NoneOrContains(item);
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            yield return new TestCaseData(Array.Empty<int>(), 1, true).SetName("Empty Collection");
+            yield return new TestCaseData(new[] { 1, 2, 3 }, 1, true).SetName("Contains Item");
+            yield return new TestCaseData(new[] { 1, 2, 3 }, 4, false).SetName("Does Not ContainItem");
+        }
+    }
+}

--- a/tests/GraphQLToKarate.Tests/Extensions/GraphQLTypeExtensionsTests.cs
+++ b/tests/GraphQLToKarate.Tests/Extensions/GraphQLTypeExtensionsTests.cs
@@ -70,4 +70,20 @@ internal sealed class GraphQLTypeExtensionsTests
         // assert
         act.Should().ThrowExactly<InvalidGraphQLTypeException>();
     }
+
+    [Test]
+    public void NameValue_should_return_correct_name_value()
+    {
+        // arrange
+        var namedNode = new GraphQLNamedType
+        {
+            Name = new GraphQLName("NamedType")
+        };
+
+        // act
+        var result = namedNode.NameValue();
+
+        // assert
+        result.Should().Be("NamedType");
+    }
 }

--- a/tests/GraphQLToKarate.Tests/Features/KarateFeatureBuilderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Features/KarateFeatureBuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using GraphQLParser.AST;
 using GraphQLToKarate.Library.Adapters;
+using GraphQLToKarate.Library.Extensions;
 using GraphQLToKarate.Library.Features;
 using GraphQLToKarate.Library.Settings;
 using GraphQLToKarate.Library.Types;
@@ -100,7 +101,7 @@ internal sealed class KarateFeatureBuilderTests
                 new Dictionary<string, string>
                 {
                     {
-                        graphQLFieldDefinition.Name.StringValue,
+                        graphQLFieldDefinition.NameValue(),
                         """"
                         Scenario: Perform a todo query and validate the response
                           * text query =
@@ -227,7 +228,7 @@ internal sealed class KarateFeatureBuilderTests
                 new Dictionary<string, string>
                 {
                     {
-                        graphQLFieldDefinition.Name.StringValue,
+                        graphQLFieldDefinition.NameValue(),
                         """"
                         Scenario: Perform a todo query and validate the response
                           * text query =
@@ -248,7 +249,7 @@ internal sealed class KarateFeatureBuilderTests
                         """"
                     },
                     {
-                        otherGraphQLFieldDefinition.Name.StringValue,
+                        otherGraphQLFieldDefinition.NameValue(),
                         """"
                         Scenario: Perform a user query and validate the response
                           * text query =
@@ -423,7 +424,7 @@ internal sealed class KarateFeatureBuilderTests
                 new Dictionary<string, string>
                 {
                     {
-                        graphQLFieldDefinition.Name.StringValue,
+                        graphQLFieldDefinition.NameValue(),
                         """"
                         Scenario: Perform a todo query and validate the response
                           * text query =


### PR DESCRIPTION
## Description

- Use existing extension method for multi-line indention everywhere it wasn't already used
- Implement `NoneOrContains` extension method, useful for optional filters
- Implement `INamedNode.NameVaue()` extension method to simplify name value retrieval
- Tests

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
