### PR TITLE
Custom Scalar Mapping Abstraction

### DIFF
--- a/resources/full_schema.graphql
+++ b/resources/full_schema.graphql
@@ -1,3 +1,7 @@
+scalar Date
+scalar URL
+scalar Long
+
 type Query {
   user(id: ID!): User
   users(filter: UserFilterInput): [User!]
@@ -10,7 +14,8 @@ type User implements Node {
   id: ID!
   name: String!
   email: String!
-  age: Int
+  age: Long!
+  birthday: Date!
   address: Address
   friends(limit: Int, offset: Int): [User!]
 }
@@ -20,6 +25,7 @@ type Address {
   city: String!
   state: String!
   zip: String!
+  url: URL
 }
 
 interface Node {
@@ -44,7 +50,8 @@ input AddressFilterInput {
   streetContains: String
   cityContains: String
   stateEquals: String
-  zipEquals: String
+  zipEquals: String,
+  url: URL
 }
 
 input UserFilterInput {

--- a/resources/graphql.feature
+++ b/resources/graphql.feature
@@ -1,0 +1,226 @@
+Feature: Test GraphQL Endpoint with Karate
+
+Background: Base URL and Schemas
+  * url baseUrl
+
+  * text userSchema =
+    """
+      {
+        id: '#string',
+        name: '#string',
+        email: '#string',
+        age: '#number',
+        birthday: '#string',
+        address: '##addressSchema',
+        friends: '##[] #userSchema'
+      }
+    """
+
+  * text addressSchema =
+    """
+      {
+        street: '#string',
+        city: '#string',
+        state: '#string',
+        zip: '#string',
+        url: '##string'
+      }
+    """
+
+  * text articleSchema =
+    """
+      {
+        id: '#string',
+        title: '#string',
+        content: '#string'
+      }
+    """
+
+  * text nodeSchema =
+    """
+      {
+        id: '#string'
+      }
+    """
+
+Scenario: Perform a user query and validate the response
+  * text query =
+    """
+      query UserTest($id: ID!) {
+        user(id: $id) {
+          id
+          name
+          email
+          age
+          birthday
+          address {
+            street
+            city
+            state
+            zip
+            url
+          }
+        }
+      }
+    """
+
+  * text variables =
+    """
+      {
+        "id": "68c06d52fec04d0d8a7ac0ace72875c0"
+      }
+    """
+
+  Given path "/graphql"
+  And request { query: query, operationName: "UserTest", variables: variables }
+  When method post
+  Then status 200
+  And match response.data.user == userSchema
+
+Scenario: Perform a users query and validate the response
+  * text query =
+    """
+      query UsersTest($filter: UserFilterInput) {
+        users(filter: $filter) {
+          id
+          name
+          email
+          age
+          birthday
+          address {
+            street
+            city
+            state
+            zip
+            url
+          }
+        }
+      }
+    """
+
+  * text variables =
+    """
+      {
+        "filter": { "nameContains": "637ccb8e8b0f4c29a973876d80cec54b", "emailContains": "da434522a30141b3a026297c67b787d6", "ageGreaterThan": 231, "ageLessThan": 905, "address": { "streetContains": "ad6dc0b6cf6940c680adf2de3f94035a", "cityContains": "8b4555c2c0c84b148531a3bcbbf45457", "stateEquals": "6844abe5dfc542b58d661854252b88e7", "zipEquals": "e4726271bd5544ca9e91295f301c018a", "url": <some value> } }
+      }
+    """
+
+  Given path "/graphql"
+  And request { query: query, operationName: "UsersTest", variables: variables }
+  When method post
+  Then status 200
+  And match each response.data.users == userSchema
+
+Scenario: Perform a search query and validate the response
+  * text query =
+    """
+      query SearchTest($query: String!, $limit: Int, $offset: Int) {
+        search(query: $query) {
+          ... on User {
+            id
+            name
+            email
+            age
+            birthday
+            address {
+              street
+              city
+              state
+              zip
+              url
+            }
+            friends(limit: $limit, offset: $offset) {
+              id
+              name
+              email
+              age
+              birthday
+              address {
+                street
+                city
+                state
+                zip
+                url
+              }
+            }
+          }
+          ... on Article {
+            id
+            title
+            content
+          }
+        }
+      }
+    """
+
+  * text variables =
+    """
+      {
+        "query": "35fe1ec4d7034a6d91a09baa5f32e961",
+        "limit": 715,
+        "offset": 649
+      }
+    """
+
+  * def isValid =
+    """
+    response =>
+      karate.match(response, userSchema).pass ||
+      karate.match(response, articleSchema).pass
+    """
+
+  Given path "/graphql"
+  And request { query: query, operationName: "SearchTest", variables: variables }
+  When method post
+  Then status 200
+  And match each response.data.search == "#? isValid(_)"
+
+Scenario: Perform a article query and validate the response
+  * text query =
+    """
+      query ArticleTest($id: ID!) {
+        article(id: $id) {
+          id
+          title
+          content
+        }
+      }
+    """
+
+  * text variables =
+    """
+      {
+        "id": "b9f3dd7defcc4d81a548a152567d7ded"
+      }
+    """
+
+  Given path "/graphql"
+  And request { query: query, operationName: "ArticleTest", variables: variables }
+  When method post
+  Then status 200
+  And match response.data.article == articleSchema
+
+Scenario: Perform a articles query and validate the response
+  * text query =
+    """
+      query ArticlesTest($input: ArticleInput) {
+        articles(input: $input) {
+          id
+          title
+          content
+        }
+      }
+    """
+
+  * text variables =
+    """
+      {
+        "input": { "titleContains": "ff281cc50c5e40f4bc212fbefad3f26c", "contentContains": "3560d172b0434622b761f89a5c95ae56", "authorId": "2fc98ef9a8374923be58c8e5187d8468" }
+      }
+    """
+
+  Given path "/graphql"
+  And request { query: query, operationName: "ArticlesTest", variables: variables }
+  When method post
+  Then status 200
+  And match each response.data.articles == articleSchema

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
@@ -22,7 +22,7 @@ internal sealed class ConvertCommandSettingsLoader : IConvertCommandSettingsLoad
 
         var customScalarMapping = convertCommandSettings.CustomScalarMapping is not null
             ? await LoadCustomScalarMapping(convertCommandSettings)
-            : new Dictionary<string, string>();
+            : new CustomScalarMapping();
 
         return new LoadedConvertCommandSettings
         {
@@ -37,11 +37,9 @@ internal sealed class ConvertCommandSettingsLoader : IConvertCommandSettingsLoad
         };
     }
 
-    private async Task<IDictionary<string, string>> LoadCustomScalarMapping(
+    private async Task<ICustomScalarMapping> LoadCustomScalarMapping(
         ConvertCommandSettings convertCommandSettings)
     {
-        var customScalarMapping = new Dictionary<string, string>();
-
         if (_customScalarMappingLoader.IsTextLoadable(convertCommandSettings.CustomScalarMapping!))
         {
             return _customScalarMappingLoader.LoadFromText(convertCommandSettings.CustomScalarMapping!);
@@ -52,6 +50,6 @@ internal sealed class ConvertCommandSettingsLoader : IConvertCommandSettingsLoad
             return await _customScalarMappingLoader.LoadFromFileAsync(convertCommandSettings.CustomScalarMapping!);
         }
 
-        return customScalarMapping;
+        return new CustomScalarMapping();
     }
 }

--- a/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
@@ -1,10 +1,12 @@
-﻿namespace GraphQLToKarate.CommandLine.Settings;
+﻿using GraphQLToKarate.Library.Mappings;
+
+namespace GraphQLToKarate.CommandLine.Settings;
 
 internal sealed class LoadedConvertCommandSettings
 {
     public required string GraphQLSchema { get; init; }
 
-    public required IDictionary<string, string> CustomScalarMapping { get; init; }
+    public required ICustomScalarMapping CustomScalarMapping { get; init; }
 
     public required string OutputFile { get; init; }
 

--- a/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using GraphQLToKarate.Library.Converters;
 using GraphQLToKarate.Library.Features;
+using GraphQLToKarate.Library.Mappings;
 using GraphQLToKarate.Library.Parsers;
 using GraphQLToKarate.Library.Settings;
 using GraphQLToKarate.Library.Tokens;
@@ -26,7 +27,7 @@ public sealed class GraphQLToKarateConverterBuilder :
     public IConfigurableGraphQLToKarateConverterBuilder Configure() => new GraphQLToKarateConverterBuilder();
 
     public IConfigurableGraphQLToKarateConverterBuilder WithCustomScalarMapping(
-        IDictionary<string, string> customScalarMapping)
+        ICustomScalarMapping customScalarMapping)
     {
         _graphQLTypeConverter = customScalarMapping.Any()
             ? new GraphQLCustomScalarTypeConverter(customScalarMapping, new GraphQLTypeConverter())

--- a/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace GraphQLToKarate.Library.Builders;
+﻿using GraphQLToKarate.Library.Mappings;
+
+namespace GraphQLToKarate.Library.Builders;
 
 /// <summary>
 ///     A <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with methods providing configuration options.
@@ -11,7 +13,7 @@ public interface IConfigurableGraphQLToKarateConverterBuilder : IConfiguredGraph
     /// </summary>
     /// <param name="customScalarMapping">The custom scalar mapping to use.</param>
     /// <returns>An <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with the given custom scalar mapping.</returns>
-    IConfigurableGraphQLToKarateConverterBuilder WithCustomScalarMapping(IDictionary<string, string> customScalarMapping);
+    IConfigurableGraphQLToKarateConverterBuilder WithCustomScalarMapping(ICustomScalarMapping customScalarMapping);
 
     /// <summary>
     ///     Configure the converter with the given <paramref name="baseUrl"/>. This allows the

--- a/src/GraphQLToKarate.Library/Converters/GraphQLCustomScalarTypeConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLCustomScalarTypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿using GraphQLParser.AST;
 using GraphQLToKarate.Library.Adapters;
 using GraphQLToKarate.Library.Extensions;
+using GraphQLToKarate.Library.Mappings;
 using GraphQLToKarate.Library.Types;
 
 namespace GraphQLToKarate.Library.Converters;
@@ -8,11 +9,11 @@ namespace GraphQLToKarate.Library.Converters;
 /// <inheritdoc cref="IGraphQLTypeConverter"/>
 public sealed class GraphQLCustomScalarTypeConverter : IGraphQLTypeConverter
 {
-    private readonly IDictionary<string, string> _customScalarMapping;
+    private readonly ICustomScalarMapping _customScalarMapping;
     private readonly IGraphQLTypeConverter _graphQLTypeConverter;
 
     public GraphQLCustomScalarTypeConverter(
-        IDictionary<string, string> customScalarMapping,
+        ICustomScalarMapping customScalarMapping,
         IGraphQLTypeConverter graphQLTypeConverter)
     {
         _customScalarMapping = customScalarMapping;
@@ -23,7 +24,7 @@ public sealed class GraphQLCustomScalarTypeConverter : IGraphQLTypeConverter
         string graphQLFieldName,
         GraphQLType graphQLType,
         IGraphQLDocumentAdapter graphQLDocumentAdapter
-    ) => _customScalarMapping.TryGetValue(graphQLType.GetTypeName(), out var karateType)
+    ) => _customScalarMapping.TryGetKarateType(graphQLType.GetTypeName(), out var karateType)
         ? new KarateType(karateType, graphQLFieldName)
         : _graphQLTypeConverter.Convert(graphQLFieldName, graphQLType, graphQLDocumentAdapter);
 }

--- a/src/GraphQLToKarate.Library/Mappings/CustomScalarMapping.cs
+++ b/src/GraphQLToKarate.Library/Mappings/CustomScalarMapping.cs
@@ -1,0 +1,17 @@
+﻿namespace GraphQLToKarate.Library.Mappings;
+
+/// <inheritdoc cref="ICustomScalarMapping"/>
+public sealed class CustomScalarMapping : ICustomScalarMapping
+{
+    public IDictionary<string, string> Mappings { get; }
+
+    public CustomScalarMapping() => Mappings = new Dictionary<string, string>();
+
+    public CustomScalarMapping(IDictionary<string, string> mappings) =>
+        Mappings = mappings;
+
+    public bool TryGetKarateType(string graphQLType, out string karateType) =>
+        Mappings.TryGetValue(graphQLType, out karateType!);
+
+    public bool Any() => Mappings.Any();
+}

--- a/src/GraphQLToKarate.Library/Mappings/CustomScalarMappingLoader.cs
+++ b/src/GraphQLToKarate.Library/Mappings/CustomScalarMappingLoader.cs
@@ -46,21 +46,22 @@ public sealed class CustomScalarMappingLoader : ICustomScalarMappingLoader
 
     public bool IsTextLoadable(string text) => _regex.IsMatch(text);
 
-    public IDictionary<string, string> LoadFromFile(string filePath) =>
+    public ICustomScalarMapping LoadFromFile(string filePath) =>
         DeserializeFileContent(_file.ReadAllText(filePath));
 
-    public async Task<IDictionary<string, string>> LoadFromFileAsync(string filePath) =>
+    public async Task<ICustomScalarMapping> LoadFromFileAsync(string filePath) =>
         DeserializeFileContent(await _file.ReadAllTextAsync(filePath));
 
-    private IDictionary<string, string> DeserializeFileContent(string fileContent) => IsTextLoadable(fileContent)
+    private ICustomScalarMapping DeserializeFileContent(string fileContent) => IsTextLoadable(fileContent)
         ? LoadFromText(fileContent)
-        : JsonSerializer.Deserialize<IDictionary<string, string>>(fileContent)!;
+        : new CustomScalarMapping(JsonSerializer.Deserialize<IDictionary<string, string>>(fileContent)!);
 
-    public IDictionary<string, string> LoadFromText(string text) => text
-        .Split(SchemaToken.Comma, StringSplitOptions.TrimEntries)
-        .Select(customScalarMappingEntry => customScalarMappingEntry.Split(SchemaToken.Colon, StringSplitOptions.TrimEntries))
-        .ToDictionary(
-            customScalarMappingEntryParts => customScalarMappingEntryParts.First(),
-            customScalarMappingEntryParts => customScalarMappingEntryParts.Last()
-        );
+    public ICustomScalarMapping LoadFromText(string text) => new CustomScalarMapping(
+        text.Split(SchemaToken.Comma, StringSplitOptions.TrimEntries)
+            .Select(customScalarMappingEntry => customScalarMappingEntry.Split(SchemaToken.Colon, StringSplitOptions.TrimEntries))
+            .ToDictionary(
+                customScalarMappingEntryParts => customScalarMappingEntryParts.First(),
+                customScalarMappingEntryParts => customScalarMappingEntryParts.Last()
+            )
+    );
 }

--- a/src/GraphQLToKarate.Library/Mappings/ICustomScalarMapping.cs
+++ b/src/GraphQLToKarate.Library/Mappings/ICustomScalarMapping.cs
@@ -1,0 +1,26 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace GraphQLToKarate.Library.Mappings;
+
+/// <summary>
+///     Represents a mapping of GraphQL custom scalar types to Karate data types.
+/// </summary>
+public interface ICustomScalarMapping
+{
+    /// <summary>
+    ///     Gets the Karate data type for the specified GraphQL custom scalar type.
+    /// </summary>
+    /// <param name="graphQLType">The GraphQL custom scalar type.</param>
+    /// <param name="karateType">The Karate data type to retrieve.</param>
+    /// <returns><c>true</c> if the mapping was found; otherwise, <c>false</c>.</returns>
+    bool TryGetKarateType(
+        string graphQLType,
+        [MaybeNullWhen(false)] out string karateType
+    );
+
+    /// <summary>
+    ///    Determines whether the mapping contains any custom scalar types.
+    /// </summary>
+    /// <returns><c>true</c> if the mapping contains any custom scalar types; otherwise, <c>false</c>.</returns>
+    bool Any();
+}

--- a/src/GraphQLToKarate.Library/Mappings/ICustomScalarMappingLoader.cs
+++ b/src/GraphQLToKarate.Library/Mappings/ICustomScalarMappingLoader.cs
@@ -10,20 +10,20 @@ public interface ICustomScalarMappingLoader : ICustomScalarMappingValidator
     ///     Load the custom scalar mapping from the given file path.
     /// </summary>
     /// <param name="filePath">The file path to load the custom scalar mapping from.</param>
-    /// <returns>The custom scalar mapping, represented as a dictionary.</returns>
-    IDictionary<string, string> LoadFromFile(string filePath);
+    /// <returns>The custom scalar mapping.</returns>
+    ICustomScalarMapping LoadFromFile(string filePath);
 
     /// <summary>
     ///     Load the custom scalar mapping from the given file path.
     /// </summary>
     /// <param name="filePath">The file path to load the custom scalar mapping from.</param>
-    /// <returns>The custom scalar mapping, represented as a dictionary.</returns>
-    Task<IDictionary<string, string>> LoadFromFileAsync(string filePath);
+    /// <returns>The custom scalar mapping.</returns>
+    Task<ICustomScalarMapping> LoadFromFileAsync(string filePath);
 
     /// <summary>
     ///     Load the custom scalar mapping from the given text.
     /// </summary>
     /// <param name="text">The text to load the custom scalar mapping from.</param>
-    /// <returns>The custom scalar mapping, represented as a dictionary.</returns>
-    IDictionary<string, string> LoadFromText(string text);
+    /// <returns>The custom scalar mapping.</returns>
+    ICustomScalarMapping LoadFromText(string text);
 }

--- a/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
@@ -77,7 +77,7 @@ internal sealed class ConvertCommandTests
             {
                 GraphQLSchema = schemaFileContent,
                 OutputFile = convertCommandSettings.OutputFile!,
-                CustomScalarMapping = new Dictionary<string, string>(),
+                CustomScalarMapping = new CustomScalarMapping(),
                 ExcludeQueries = convertCommandSettings.ExcludeQueries,
                 BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl",
                 QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query,

--- a/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
@@ -69,7 +69,7 @@ internal sealed class CommandAppConfiguratorTests
             {
                 GraphQLSchema = "some GraphQL schema",
                 OutputFile = "graphql.feature",
-                CustomScalarMapping = new Dictionary<string, string>(),
+                CustomScalarMapping = new CustomScalarMapping(),
                 ExcludeQueries = false,
                 BaseUrl = "baseUrl",
                 QueryName = GraphQLToken.Query,

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
@@ -95,12 +95,14 @@ internal sealed class ConvertCommandSettingsLoaderTests
             .ReadAllTextAsync(convertCommandSettings.InputFile)
             .Returns(SomeGraphQLSchema);
 
-        var expectedCustomScalarMapping = new Dictionary<string, string>
-        {
-            { "key1", "value1" },
-            { "key2", "value2" },
-            { "key3", "value3" }
-        };
+        var expectedCustomScalarMapping = new CustomScalarMapping(
+            new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" },
+                { "key3", "value3" }
+            }
+        );
 
         _mockCustomScalarMappingLoader!
             .IsFileLoadable(convertCommandSettings.CustomScalarMapping)
@@ -153,7 +155,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
             .ReadAllTextAsync(convertCommandSettings.InputFile)
             .Returns(SomeGraphQLSchema);
 
-        var expectedCustomScalarMapping = new Dictionary<string, string>();
+        var expectedCustomScalarMapping = new CustomScalarMapping();
 
         // act
         var loadedConvertCommandSettings = await _subjectUnderTest!.LoadAsync(convertCommandSettings);
@@ -192,7 +194,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
             .IsTextLoadable(convertCommandSettings.CustomScalarMapping)
             .Returns(false);
 
-        var expectedCustomScalarMapping = new Dictionary<string, string>();
+        var expectedCustomScalarMapping = new CustomScalarMapping();
 
         // act
         var loadedConvertCommandSettings = await _subjectUnderTest!.LoadAsync(convertCommandSettings);

--- a/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using GraphQLToKarate.Library.Builders;
 using GraphQLToKarate.Library.Converters;
+using GraphQLToKarate.Library.Mappings;
 using NUnit.Framework;
 
 namespace GraphQLToKarate.Tests.Builders;
@@ -14,9 +15,11 @@ internal sealed class GraphQLToKarateConverterBuilderTests
     public void Build_builds_expected_converter(bool populateCustomScalarMapping)
     {
         // arrange
-        var customScalarMapping = populateCustomScalarMapping
-            ? new Dictionary<string, string> { { "hello", "world" } }
-            : new Dictionary<string, string>();
+        var customScalarMapping = new CustomScalarMapping(
+            populateCustomScalarMapping
+                ? new Dictionary<string, string> { { "hello", "world" } }
+                : new Dictionary<string, string>()
+        );
 
         var subjectUnderTest = new GraphQLToKarateConverterBuilder();
 

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLCustomScalarTypeConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLCustomScalarTypeConverterTests.cs
@@ -3,6 +3,7 @@ using GraphQLParser.AST;
 using GraphQLToKarate.Library.Adapters;
 using GraphQLToKarate.Library.Converters;
 using GraphQLToKarate.Library.Extensions;
+using GraphQLToKarate.Library.Mappings;
 using GraphQLToKarate.Library.Tokens;
 using GraphQLToKarate.Library.Types;
 using NSubstitute;
@@ -15,7 +16,7 @@ namespace GraphQLToKarate.Tests.Converters;
 internal sealed class GraphQLCustomScalarTypeConverterTests
 {
     private IGraphQLTypeConverter? _mockGraphQLTypeConverter;
-    private IDictionary<string, string>? _customScalarMapping;
+    private ICustomScalarMapping? _customScalarMapping;
     private IGraphQLTypeConverter? _subjectUnderTest;
 
     private const string CustomScalarNameLong = "Long";
@@ -26,11 +27,13 @@ internal sealed class GraphQLCustomScalarTypeConverterTests
     {
         _mockGraphQLTypeConverter = Substitute.For<IGraphQLTypeConverter>();
 
-        _customScalarMapping = new Dictionary<string, string>
-        {
-            { CustomScalarNameLong, KarateToken.Number },
-            { CustomScalarNameTime, KarateToken.String }
-        };
+        _customScalarMapping = new CustomScalarMapping(
+            new Dictionary<string, string>
+            {
+                { CustomScalarNameLong, KarateToken.Number },
+                { CustomScalarNameTime, KarateToken.String }
+            }
+        );
 
         _subjectUnderTest = new GraphQLCustomScalarTypeConverter(
             _customScalarMapping!,
@@ -47,7 +50,7 @@ internal sealed class GraphQLCustomScalarTypeConverterTests
         KarateTypeBase expectedKarateType)
     {
         // arrange
-        var shouldCallUnderlyingGraphQLTypeConverter = !_customScalarMapping!.ContainsKey(graphQLType.GetTypeName());
+        var shouldCallUnderlyingGraphQLTypeConverter = !_customScalarMapping!.TryGetKarateType(graphQLType.GetTypeName(), out _);
 
         if (shouldCallUnderlyingGraphQLTypeConverter)
         {

--- a/tests/GraphQLToKarate.Tests/Mappings/CustomScalarMappingLoaderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Mappings/CustomScalarMappingLoaderTests.cs
@@ -105,12 +105,13 @@ internal sealed class CustomScalarMappingLoaderTests
 
         // assert
         customScalarMapping.Should().BeEquivalentTo(
-            new Dictionary<string, string>
-            {
-                { "DateTime", "string" },
-                { "Long", "number" },
-                { "URL", "string" }
-            }
+            new CustomScalarMapping(new Dictionary<string, string>
+                {
+                    { "DateTime", "string" },
+                    { "Long", "number" },
+                    { "URL", "string" }
+                }
+            )
         );
     }
 
@@ -134,12 +135,14 @@ internal sealed class CustomScalarMappingLoaderTests
 
         // assert
         customScalarMapping.Should().BeEquivalentTo(
-            new Dictionary<string, string>
-            {
-                { "DateTime", "string" },
-                { "Long", "number" },
-                { "URL", "string" }
-            }
+            new CustomScalarMapping(
+                new Dictionary<string, string>
+                {
+                    { "DateTime", "string" },
+                    { "Long", "number" },
+                    { "URL", "string" }
+                }
+            )
         );
     }
 
@@ -153,12 +156,14 @@ internal sealed class CustomScalarMappingLoaderTests
 
         // assert
         customScalarMapping.Should().BeEquivalentTo(
-            new Dictionary<string, string>
-            {
-                { "DateTime", "string" },
-                { "Long", "number" },
-                { "URL", "string" }
-            }
+            new CustomScalarMapping(
+                new Dictionary<string, string>
+                {
+                    { "DateTime", "string" },
+                    { "Long", "number" },
+                    { "URL", "string" }
+                }
+            )
         );
     }
 }

--- a/tests/GraphQLToKarate.Tests/Mappings/CustomScalarMappingTest.cs
+++ b/tests/GraphQLToKarate.Tests/Mappings/CustomScalarMappingTest.cs
@@ -1,0 +1,56 @@
+﻿using FluentAssertions;
+using GraphQLToKarate.Library.Mappings;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.Tests.Mappings;
+
+[TestFixture]
+public class CustomScalarMappingTests
+{
+    [TestCase("String", "string")]
+    [TestCase("Int", "int")]
+    [TestCase("Boolean", "boolean")]
+    public void TryGetKarateType_should_return_true_and_karate_type_when_mapping_exists(string graphQLType, string expectedKarateType)
+    {
+        // arrange
+        var customScalarMapping = new CustomScalarMapping(
+            new Dictionary<string, string>
+            {
+                { "String", "string" },
+                { "Int", "int" },
+                { "Boolean", "boolean" }
+            }
+        );
+
+        // act
+        var result = customScalarMapping.TryGetKarateType(graphQLType, out var karateType);
+
+        // assert
+        customScalarMapping.Any().Should().BeTrue();
+        result.Should().BeTrue();
+        karateType.Should().Be(expectedKarateType);
+    }
+
+    [TestCase("Float")]
+    [TestCase("ID")]
+    public void TryGetKarateType_should_return_false_and_null_karate_type_when_mapping_does_not_exist(string graphQLType)
+    {
+        // arrange
+        var customScalarMapping = new CustomScalarMapping(
+            new Dictionary<string, string>
+            {
+                { "String", "string" },
+                { "Int", "int" },
+                { "Boolean", "boolean" }
+            }
+        );
+
+        // act
+        var result = customScalarMapping.TryGetKarateType(graphQLType, out var karateType);
+
+        // assert
+        customScalarMapping.Any().Should().BeTrue();
+        result.Should().BeFalse();
+        karateType.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Description

Create an abstraction for custom scalar mappings, so `IDictionary<string, string>` stops getting passed around with no semantic context. The underlying `Mappings` dictionary is still exposed publicly, for convenience.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
