### PR TITLE
Allow Custom Mutation Name

### DIFF
--- a/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
+++ b/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
@@ -37,6 +37,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommandSettings>
             .WithCustomScalarMapping(loadedCommandSettings.CustomScalarMapping)
             .WithExcludeQueriesSetting(commandSettings.ExcludeQueries)
             .WithQueryName(loadedCommandSettings.QueryName)
+            .WithMutationName(loadedCommandSettings.MutationName)
             .WithTypeFilter(loadedCommandSettings.TypeFilter)
             .WithOperationFilter(loadedCommandSettings.OperationFilter)
             .Build();

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
@@ -47,6 +47,11 @@ internal sealed class ConvertCommandSettings : LogCommandSettings
     [DefaultValue(typeof(string), GraphQLToken.Query)]
     public string? QueryName { get; set; } = GraphQLToken.Query;
 
+    [CommandOption("--mutation-name")]
+    [Description("The name of the GraphQL mutation type")]
+    [DefaultValue(typeof(string), GraphQLToken.Mutation)]
+    public string? MutationName { get; set; } = GraphQLToken.Mutation;
+
     [CommandOption("--type-filter")]
     [Description("A comma-separated list of GraphQL types to include in the Karate feature")]
     [TypeConverter(typeof(StringToSetConverter))]

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
@@ -32,6 +32,7 @@ internal sealed class ConvertCommandSettingsLoader : IConvertCommandSettingsLoad
             BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl",
             ExcludeQueries = convertCommandSettings.ExcludeQueries,
             QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query,
+            MutationName = convertCommandSettings.MutationName ?? GraphQLToken.Mutation,
             TypeFilter = convertCommandSettings.TypeFilter,
             OperationFilter = convertCommandSettings.OperationFilter
         };

--- a/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
@@ -16,6 +16,8 @@ internal sealed class LoadedConvertCommandSettings
 
     public required string QueryName { get; init; }
 
+    public required string MutationName { get; init; }
+
     public required ISet<string> TypeFilter { get; init; }
 
     public required ISet<string> OperationFilter { get; init; }

--- a/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
@@ -21,6 +21,8 @@ public sealed class GraphQLToKarateConverterBuilder :
 
     private string _queryName = GraphQLToken.Query;
 
+    private string _mutationName = GraphQLToken.Mutation;
+
     private ISet<string> _typeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     private ISet<string> _operationFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -68,6 +70,13 @@ public sealed class GraphQLToKarateConverterBuilder :
         return this;
     }
 
+    public IConfigurableGraphQLToKarateConverterBuilder WithMutationName(string mutationName)
+    {
+        _mutationName = mutationName;
+
+        return this;
+    }
+
     public IConfigurableGraphQLToKarateConverterBuilder WithTypeFilter(ISet<string> typeFilter)
     {
         _typeFilter = typeFilter;
@@ -107,6 +116,7 @@ public sealed class GraphQLToKarateConverterBuilder :
         {
             ExcludeQueries = _excludeQueriesSetting,
             QueryName = _queryName,
+            MutationName = _mutationName,
             TypeFilter = _typeFilter,
             OperationFilter = _operationFilter
         }

--- a/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/IConfigurableGraphQLToKarateConverterBuilder.cs
@@ -41,6 +41,13 @@ public interface IConfigurableGraphQLToKarateConverterBuilder : IConfiguredGraph
     IConfigurableGraphQLToKarateConverterBuilder WithQueryName(string queryName);
 
     /// <summary>
+    ///   Configure the converter with the given <paramref name="mutationName"/>. This allows the user to specify a
+    /// </summary>
+    /// <param name="mutationName">The name of the mutation type.</param>
+    /// <returns>An <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> with the given mutation name.</returns>
+    IConfigurableGraphQLToKarateConverterBuilder WithMutationName(string mutationName);
+
+    /// <summary>
     ///    Configure the converter with the given <paramref name="typeFilter"/>. This allows the user to specify
     ///    which GraphQL types to include in the output, if they'd like to filter them.
     /// </summary>

--- a/src/GraphQLToKarate.Library/Converters/GraphQLToKarateConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLToKarateConverter.cs
@@ -4,7 +4,6 @@ using GraphQLToKarate.Library.Extensions;
 using GraphQLToKarate.Library.Features;
 using GraphQLToKarate.Library.Parsers;
 using GraphQLToKarate.Library.Settings;
-using GraphQLToKarate.Library.Tokens;
 using GraphQLToKarate.Library.Types;
 using Microsoft.Extensions.Logging;
 
@@ -48,7 +47,7 @@ public sealed class GraphQLToKarateConverter : IGraphQLToKarateConverter
                     StringComparison.OrdinalIgnoreCase
                 )
                 && !definition.NameValue().Equals(
-                    GraphQLToken.Mutation,
+                    _graphQLToKarateConverterSettings.MutationName,
                     StringComparison.OrdinalIgnoreCase
                 )
                 && _graphQLToKarateConverterSettings.TypeFilter.NoneOrContains(definition.NameValue())

--- a/src/GraphQLToKarate.Library/Settings/GraphQLToKarateConverterSettings.cs
+++ b/src/GraphQLToKarate.Library/Settings/GraphQLToKarateConverterSettings.cs
@@ -10,6 +10,8 @@ public sealed class GraphQLToKarateConverterSettings
 
     public string QueryName { get; init; } = GraphQLToken.Query;
 
+    public string MutationName { get; init; } = GraphQLToken.Mutation;
+
     public ISet<string> TypeFilter { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     public ISet<string> OperationFilter { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
@@ -81,6 +81,7 @@ internal sealed class ConvertCommandTests
                 ExcludeQueries = convertCommandSettings.ExcludeQueries,
                 BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl",
                 QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query,
+                MutationName = convertCommandSettings.MutationName ?? GraphQLToken.Mutation,
                 TypeFilter = convertCommandSettings.TypeFilter,
                 OperationFilter = convertCommandSettings.OperationFilter
             });

--- a/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
@@ -73,6 +73,7 @@ internal sealed class CommandAppConfiguratorTests
                 ExcludeQueries = false,
                 BaseUrl = "baseUrl",
                 QueryName = GraphQLToken.Query,
+                MutationName = GraphQLToken.Mutation,
                 TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase),
                 OperationFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             });

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
@@ -81,6 +81,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
             BaseUrl = "baseUrl",
             ExcludeQueries = false,
             QueryName = GraphQLToken.Query,
+            MutationName = GraphQLToken.Mutation,
             TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "Hello"
@@ -135,6 +136,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
         loadedConvertCommandSettings.BaseUrl.Should().Be(convertCommandSettings.BaseUrl);
         loadedConvertCommandSettings.ExcludeQueries.Should().Be(convertCommandSettings.ExcludeQueries);
         loadedConvertCommandSettings.QueryName.Should().Be(convertCommandSettings.QueryName);
+        loadedConvertCommandSettings.MutationName.Should().Be(convertCommandSettings.MutationName);
         loadedConvertCommandSettings.TypeFilter.Should().BeEquivalentTo(convertCommandSettings.TypeFilter);
         loadedConvertCommandSettings.OperationFilter.Should().BeEquivalentTo(convertCommandSettings.OperationFilter);
     }
@@ -148,7 +150,8 @@ internal sealed class ConvertCommandSettingsLoaderTests
             InputFile = "schema.graphql",
             CustomScalarMapping = null,
             OutputFile = "karate.feature",
-            QueryName = null
+            QueryName = null,
+            MutationName = null
         };
 
         _mockFile!
@@ -167,6 +170,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
         loadedConvertCommandSettings.BaseUrl.Should().Be(convertCommandSettings.BaseUrl);
         loadedConvertCommandSettings.ExcludeQueries.Should().Be(convertCommandSettings.ExcludeQueries);
         loadedConvertCommandSettings.QueryName.Should().Be(GraphQLToken.Query);
+        loadedConvertCommandSettings.MutationName.Should().Be(GraphQLToken.Mutation);
         loadedConvertCommandSettings.TypeFilter.Should().BeEquivalentTo(convertCommandSettings.TypeFilter);
         loadedConvertCommandSettings.OperationFilter.Should().BeEquivalentTo(convertCommandSettings.OperationFilter);
     }

--- a/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
@@ -37,6 +37,7 @@ internal sealed class GraphQLToKarateConverterBuilderTests
             .WithBaseUrl("https://www.builder-test.com/graphql")
             .WithExcludeQueriesSetting(false)
             .WithQueryName("Hello")
+            .WithMutationName("World")
             .WithTypeFilter(new HashSet<string> { "Test" })
             .WithOperationFilter(new HashSet<string> { "todos" })
             .Build();


### PR DESCRIPTION
## Description

Allow users to specify custom mutation names. For now this is just for filtering out mutations from the generated Karate features, but may be used to generate mutation Karate scenarios later.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
