### PR TITLE
More Cleanup

### DIFF
--- a/src/GraphQLToKarate.Library/Adapters/IGraphQLDocumentAdapter.cs
+++ b/src/GraphQLToKarate.Library/Adapters/IGraphQLDocumentAdapter.cs
@@ -7,6 +7,14 @@ namespace GraphQLToKarate.Library.Adapters;
 /// </summary>
 public interface IGraphQLDocumentAdapter
 {
+    GraphQLObjectTypeDefinition? GraphQLQueryTypeDefinition { get; }
+
+    GraphQLObjectTypeDefinition? GraphQLMutationTypeDefinition { get; }
+
+    IEnumerable<GraphQLObjectTypeDefinition> GraphQLObjectTypeDefinitions { get; }
+
+    IEnumerable<GraphQLInterfaceTypeDefinition> GraphQLInterfaceTypeDefinitions { get; }
+
     /// <summary>
     ///     Is the given <paramref name="graphQLTypeDefinitionName"/> a <see cref="GraphQLEnumTypeDefinition"/>?
     /// </summary>

--- a/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
@@ -13,7 +13,7 @@ public sealed class GraphQLToKarateConverterBuilder :
     IGraphQLToKarateConverterBuilder,
     IConfigurableGraphQLToKarateConverterBuilder
 {
-    private IGraphQLTypeConverter? _graphQLTypeConverter;
+    private IGraphQLTypeConverter _graphQLTypeConverter = new GraphQLTypeConverter();
 
     private bool _excludeQueriesSetting;
 
@@ -94,7 +94,7 @@ public sealed class GraphQLToKarateConverterBuilder :
     public IGraphQLToKarateConverter Build() => new GraphQLToKarateConverter(
         new GraphQLSchemaParser(),
         new GraphQLTypeDefinitionConverter(
-            new GraphQLTypeConverterFactory(_graphQLTypeConverter ?? new GraphQLTypeConverter())
+            new GraphQLTypeConverterFactory(_graphQLTypeConverter)
         ),
         new GraphQLFieldDefinitionConverter(
             new GraphQLInputValueDefinitionConverterFactory(

--- a/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
@@ -112,7 +112,7 @@ public sealed class GraphQLToKarateConverterBuilder :
             }
         ),
         _graphQLToKarateConverterLogger,
-        new GraphQLToKarateConverterSettings
+        new GraphQLToKarateSettings
         {
             ExcludeQueries = _excludeQueriesSetting,
             QueryName = _queryName,

--- a/src/GraphQLToKarate.Library/Builders/IGraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/IGraphQLToKarateConverterBuilder.cs
@@ -7,5 +7,9 @@ namespace GraphQLToKarate.Library.Builders;
 /// </summary>
 public interface IGraphQLToKarateConverterBuilder
 {
+    /// <summary>
+    ///     Begin configuring a new <see cref="IGraphQLToKarateConverter"/>.
+    /// </summary>
+    /// <returns>A <see cref="IConfigurableGraphQLToKarateConverterBuilder"/> to configure the <see cref="IGraphQLToKarateConverter"/> with.</returns>
     IConfigurableGraphQLToKarateConverterBuilder Configure();
 }

--- a/src/GraphQLToKarate.Library/Converters/GraphQLCustomScalarTypeConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLCustomScalarTypeConverter.cs
@@ -24,7 +24,7 @@ public sealed class GraphQLCustomScalarTypeConverter : IGraphQLTypeConverter
         string graphQLFieldName,
         GraphQLType graphQLType,
         IGraphQLDocumentAdapter graphQLDocumentAdapter
-    ) => _customScalarMapping.TryGetKarateType(graphQLType.GetTypeName(), out var karateType)
+    ) => _customScalarMapping.TryGetKarateType(graphQLType.GetUnwrappedTypeName(), out var karateType)
         ? new KarateType(karateType, graphQLFieldName)
         : _graphQLTypeConverter.Convert(graphQLFieldName, graphQLType, graphQLDocumentAdapter);
 }

--- a/src/GraphQLToKarate.Library/Converters/GraphQLFieldDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLFieldDefinitionConverter.cs
@@ -44,7 +44,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
         AdjacencyGraph<string, Edge<string>> fieldRelationshipsGraph,
         int indentationLevel = 0)
     {
-        var graphQLFieldDefinitionTypeName = graphQLFieldDefinition.Type.GetTypeName();
+        var graphQLFieldDefinitionTypeName = graphQLFieldDefinition.Type.GetUnwrappedTypeName();
 
         fieldRelationshipsGraph.AddVertex(graphQLFieldDefinitionTypeName);
 
@@ -136,7 +136,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
 
         foreach (var graphQLNamedType in graphQLUnionTypeDefinition.Types!)
         {
-            var graphQLTypeName = graphQLNamedType.GetTypeName();
+            var graphQLTypeName = graphQLNamedType.GetUnwrappedTypeName();
 
             stringBuilder.AppendLine($"... on {graphQLTypeName} {SchemaToken.OpenBrace}".Indent(indentationLevel + 4));
 
@@ -169,7 +169,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
     {
         foreach (var childGraphQLFieldDefinition in graphQLTypeDefinitionWithFields.Fields!)
         {
-            var childGraphQLFieldDefinitionTypeName = childGraphQLFieldDefinition.Type.GetTypeName();
+            var childGraphQLFieldDefinitionTypeName = childGraphQLFieldDefinition.Type.GetUnwrappedTypeName();
 
             fieldRelationships.AddVertex(childGraphQLFieldDefinitionTypeName);
 
@@ -207,7 +207,7 @@ public sealed class GraphQLFieldDefinitionConverter : IGraphQLFieldDefinitionCon
         AdjacencyGraph<string, Edge<string>> fieldRelationships,
         int indentationLevel)
     {
-        var graphQLFieldDefinitionTypeName = graphQLFieldDefinition.Type.GetTypeName();
+        var graphQLFieldDefinitionTypeName = graphQLFieldDefinition.Type.GetUnwrappedTypeName();
 
         if (graphQLDocumentAdapter.IsGraphQLTypeDefinitionWithFields(graphQLFieldDefinitionTypeName) ||
             graphQLDocumentAdapter.IsGraphQLUnionTypeDefinition(graphQLFieldDefinitionTypeName))

--- a/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLInputValueDefinitionConverter.cs
@@ -57,7 +57,7 @@ internal sealed class GraphQLInputValueDefinitionConverter : IGraphQLInputValueD
         string graphQLArgumentName,
         string graphQLVariableName,
         string exampleValue
-    ) => new GraphQLArgumentType(graphQLArgumentName, graphQLVariableName, graphQLType.GetTypeName(), exampleValue);
+    ) => new GraphQLArgumentType(graphQLArgumentName, graphQLVariableName, graphQLType.GetUnwrappedTypeName(), exampleValue);
 
     private static GraphQLArgumentTypeBase GetGraphQLListVariableType(
         GraphQLType graphQLType,

--- a/src/GraphQLToKarate.Library/Converters/GraphQLInputValueToExampleValueConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLInputValueToExampleValueConverter.cs
@@ -37,8 +37,8 @@ internal sealed class GraphQLInputValueToExampleValueConverter : IGraphQLInputVa
         GraphQLListType graphQLListType => $"[ {Convert(graphQLListType.Type, graphQLDocumentAdapter, inputValueRelationships)} ]",
         GraphQLNonNullType graphQLNonNullType => Convert(graphQLNonNullType.Type, graphQLDocumentAdapter, inputValueRelationships),
         GraphQLNamedType graphQLNamedType when
-            graphQLDocumentAdapter.IsGraphQLInputObjectTypeDefinition(graphQLNamedType.GetTypeName()) => Convert(
-                graphQLDocumentAdapter.GetGraphQLInputObjectTypeDefinition(graphQLNamedType.GetTypeName())!,
+            graphQLDocumentAdapter.IsGraphQLInputObjectTypeDefinition(graphQLNamedType.GetUnwrappedTypeName()) => Convert(
+                graphQLDocumentAdapter.GetGraphQLInputObjectTypeDefinition(graphQLNamedType.GetUnwrappedTypeName())!,
                 graphQLDocumentAdapter,
                 inputValueRelationships ?? new AdjacencyGraph<string, Edge<string>>()
             ),
@@ -65,7 +65,7 @@ internal sealed class GraphQLInputValueToExampleValueConverter : IGraphQLInputVa
         foreach (var graphQLInputValueDefinition in graphQLInputObjectTypeDefinition.Fields!)
         {
             var childInputValueName = graphQLInputValueDefinition.NameValue();
-            var childInputValueDefinitionTypeName = graphQLInputValueDefinition.Type.GetTypeName();
+            var childInputValueDefinitionTypeName = graphQLInputValueDefinition.Type.GetUnwrappedTypeName();
 
             inputValueRelationships.AddVertex(childInputValueDefinitionTypeName);
 
@@ -79,7 +79,7 @@ internal sealed class GraphQLInputValueToExampleValueConverter : IGraphQLInputVa
                 inputValueRelationships.RemoveEdge(edge);
 
                 stringBuilder.Append(
-                    graphQLInputValueDefinition.Type is GraphQLListType or GraphQLNonNullType { Type: GraphQLListType }
+                    graphQLInputValueDefinition.Type.IsListType()
                         ? $"\"{childInputValueName}\": [ <some {childInputValueDefinitionTypeName} value> ]{SchemaToken.Comma} "
                         : $"\"{childInputValueName}\": <some {childInputValueDefinitionTypeName} value>{SchemaToken.Comma} "
                 );

--- a/src/GraphQLToKarate.Library/Converters/GraphQLScalarToExampleValueConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLScalarToExampleValueConverter.cs
@@ -28,7 +28,7 @@ internal sealed class GraphQLScalarToExampleValueConverter : IGraphQLScalarToExa
         _random = new Random();
     }
 
-    public string Convert(GraphQLType graphQLType, IGraphQLDocumentAdapter graphQLDocumentAdapter) => graphQLType.GetTypeName() switch
+    public string Convert(GraphQLType graphQLType, IGraphQLDocumentAdapter graphQLDocumentAdapter) => graphQLType.GetUnwrappedTypeName() switch
     {
         GraphQLToken.Id => GenerateRandomString(),
         GraphQLToken.String => GenerateRandomString(),

--- a/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverter.cs
@@ -14,7 +14,7 @@ internal sealed class GraphQLTypeConverter : IGraphQLTypeConverter
         GraphQLType graphQLType,
         IGraphQLDocumentAdapter graphQLDocumentAdapter)
     {
-        var karateTypeSchema = graphQLType.GetTypeName() switch
+        var karateTypeSchema = graphQLType.GetUnwrappedTypeName() switch
         {
             GraphQLToken.Id => KarateToken.String,
             GraphQLToken.String => KarateToken.String,

--- a/src/GraphQLToKarate.Library/Converters/IGraphQLInputValueDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/IGraphQLInputValueDefinitionConverter.cs
@@ -20,5 +20,9 @@ public interface IGraphQLInputValueDefinitionConverter
         IGraphQLDocumentAdapter graphQLDocumentAdapter
     );
 
+    /// <summary>
+    ///     Get all of the previously converted <see cref="GraphQLArgumentTypeBase"/> types.
+    /// </summary>
+    /// <returns>All of the previously converted <see cref="GraphQLArgumentTypeBase"/> types.</returns>
     ICollection<GraphQLArgumentTypeBase> GetAllConverted();
 }

--- a/src/GraphQLToKarate.Library/Extensions/GraphQLTypeExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/GraphQLTypeExtensions.cs
@@ -10,7 +10,7 @@ internal static class GraphQLTypeExtensions
     /// </summary>
     /// <param name="graphQLType">The <see cref="GraphQLType"/> to retrieve the type name from.</param>
     /// <returns>The type name contained by the given <see cref="GraphQLType"/>.</returns>
-    public static string GetTypeName(this GraphQLType graphQLType)
+    public static string GetUnwrappedTypeName(this GraphQLType graphQLType)
     {
         while (true)
         {
@@ -36,4 +36,12 @@ internal static class GraphQLTypeExtensions
     /// <param name="namedNode">The node to retrieve the name value of</param>
     /// <returns>The string value of the node's name</returns>
     public static string NameValue(this INamedNode namedNode) => namedNode.Name.StringValue;
+
+    /// <summary>
+    ///     Return whether the given GraphQL type is a list type.
+    /// </summary>
+    /// <param name="graphQLType">The source GraphQL type to check.</param>
+    /// <returns>Whether the given GraphQL type is a list type.</returns>
+    public static bool IsListType(this GraphQLType graphQLType) =>
+        graphQLType is GraphQLListType or GraphQLNonNullType { Type: GraphQLListType };
 }

--- a/src/GraphQLToKarate.Library/Parsers/GraphQLSchemaParser.cs
+++ b/src/GraphQLToKarate.Library/Parsers/GraphQLSchemaParser.cs
@@ -4,6 +4,7 @@ using GraphQLParser.AST;
 
 namespace GraphQLToKarate.Library.Parsers;
 
+/// <inheritdoc cref="IGraphQLSchemaParser"/>
 [ExcludeFromCodeCoverage(Justification = "Just a wrapper to enable dependency injection.")]
 public sealed class GraphQLSchemaParser : IGraphQLSchemaParser
 {

--- a/src/GraphQLToKarate.Library/Settings/GraphQLToKarateSettings.cs
+++ b/src/GraphQLToKarate.Library/Settings/GraphQLToKarateSettings.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace GraphQLToKarate.Library.Settings;
 
 [ExcludeFromCodeCoverage]
-public sealed class GraphQLToKarateConverterSettings
+public sealed class GraphQLToKarateSettings
 {
     public bool ExcludeQueries { get; init; } = false;
 

--- a/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
+++ b/src/GraphQLToKarate.Library/Types/GraphQLQueryFieldType.cs
@@ -11,14 +11,11 @@ public sealed class GraphQLQueryFieldType
 
     public string OperationName => $"{Name.FirstCharToUpper()}Test";
 
-    public string ReturnTypeName => _queryField.Type.GetTypeName();
+    public string ReturnTypeName => _queryField.Type.GetUnwrappedTypeName();
 
     public bool IsNullableReturnType => _queryField.Type is not GraphQLNonNullType;
 
-    public bool IsListReturnType => _queryField.Type is GraphQLListType or GraphQLNonNullType
-    {
-        Type: GraphQLListType
-    };
+    public bool IsListReturnType => _queryField.Type.IsListType();
 
     public required string QueryString { get; init; }
 

--- a/tests/GraphQLToKarate.Tests/Adapters/GraphQLDocumentAdapterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Adapters/GraphQLDocumentAdapterTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using GraphQLParser.AST;
 using GraphQLToKarate.Library.Adapters;
+using GraphQLToKarate.Library.Tokens;
 using NUnit.Framework;
 
 namespace GraphQLToKarate.Tests.Adapters;
@@ -609,6 +610,236 @@ internal sealed class GraphQLDocumentAdapterTests
             ).SetName(
                 "When GraphQL document has specific input object type definition, input object type definition is found"
             );
+        }
+    }
+
+    [Test]
+    [TestCaseSource(nameof(GraphQLObjectTypeDefinitionsTestCases))]
+    public void GraphQLObjectTypeDefinitions_returns_expected_result(
+        IGraphQLDocumentAdapter graphQLDocumentAdapter,
+        IEnumerable<GraphQLObjectTypeDefinition> expectedResult
+    ) => graphQLDocumentAdapter
+        .GraphQLObjectTypeDefinitions
+        .Should()
+        .BeEquivalentTo(expectedResult);
+
+    private static IEnumerable<TestCaseData> GraphQLObjectTypeDefinitionsTestCases
+    {
+        get
+        {
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument()),
+                new List<GraphQLObjectTypeDefinition>()
+            ).SetName("GraphQL document with no definitions generates expected result");
+
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument
+                {
+                    Definitions = new List<ASTNode>
+                    {
+                        new GraphQLInterfaceTypeDefinition
+                        {
+                            Name = new GraphQLName("SomeInterfaceType")
+                        }
+                    }
+                }),
+                new List<GraphQLObjectTypeDefinition>()
+            ).SetName("GraphQL document with no object type definitions generates expected result");
+
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument
+                {
+                    Definitions = new List<ASTNode>
+                    {
+                        new GraphQLInterfaceTypeDefinition
+                        {
+                            Name = new GraphQLName("SomeInterfaceType")
+                        },
+                        new GraphQLObjectTypeDefinition
+                        {
+                            Name = new GraphQLName("SomeObjectType")
+                        },
+                        new GraphQLObjectTypeDefinition
+                        {
+                            Name = new GraphQLName(GraphQLToken.Query)
+                        }
+                    }
+                }),
+                new List<GraphQLObjectTypeDefinition>
+                {
+                    new()
+                    {
+                        Name = new GraphQLName("SomeObjectType")
+                    }
+                }
+            ).SetName("GraphQL document with one object type definitions generates expected result");
+        }
+    }
+
+    [Test]
+    [TestCaseSource(nameof(GraphQLInterfaceTypeDefinitionsTestCases))]
+    public void GraphQLInterfaceTypeDefinitions_returns_expected_result(
+        IGraphQLDocumentAdapter graphQLDocumentAdapter,
+        IEnumerable<GraphQLInterfaceTypeDefinition> expectedResult
+    ) => graphQLDocumentAdapter
+        .GraphQLInterfaceTypeDefinitions
+        .Should()
+        .BeEquivalentTo(expectedResult);
+
+    private static IEnumerable<TestCaseData> GraphQLInterfaceTypeDefinitionsTestCases
+    {
+        get
+        {
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument()),
+                new List<GraphQLInterfaceTypeDefinition>()
+            ).SetName("GraphQL document with no definitions generates expected result");
+
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument
+                {
+                    Definitions = new List<ASTNode>
+                    {
+                        new GraphQLObjectTypeDefinition
+                        {
+                            Name = new GraphQLName("SomeObjectType")
+                        }
+                    }
+                }),
+                new List<GraphQLInterfaceTypeDefinition>()
+            ).SetName("GraphQL document with no interface type definitions generates expected result");
+
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument
+                {
+                    Definitions = new List<ASTNode>
+                    {
+                        new GraphQLInterfaceTypeDefinition
+                        {
+                            Name = new GraphQLName("SomeInterfaceType")
+                        },
+                        new GraphQLObjectTypeDefinition
+                        {
+                            Name = new GraphQLName("SomeObjectType")
+                        },
+                        new GraphQLObjectTypeDefinition
+                        {
+                            Name = new GraphQLName(GraphQLToken.Query)
+                        }
+                    }
+                }),
+                new List<GraphQLInterfaceTypeDefinition>
+                {
+                    new()
+                    {
+                        Name = new GraphQLName("SomeInterfaceType")
+                    }
+                }
+            ).SetName("GraphQL document with one interface type definition generates expected result");
+        }
+    }
+
+    [Test]
+    [TestCaseSource(nameof(GraphQLQueryTypeDefinitionTestCases))]
+    public void GraphQLQueryTypeDefinition_returns_expected_result(
+        IGraphQLDocumentAdapter graphQLDocumentAdapter,
+        GraphQLObjectTypeDefinition? expectedResult
+    ) => graphQLDocumentAdapter
+        .GraphQLQueryTypeDefinition
+        .Should()
+        .BeEquivalentTo(expectedResult);
+
+    private static IEnumerable<TestCaseData> GraphQLQueryTypeDefinitionTestCases
+    {
+        get
+        {
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument()),
+                null
+            ).SetName("GraphQL document with no definitions returns expected result.");
+
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument
+                {
+                    Definitions = new List<ASTNode>
+                    {
+                        new GraphQLInterfaceTypeDefinition
+                        {
+                            Name = new GraphQLName("SomeInterfaceType")
+                        }
+                    }
+                }),
+                null
+            ).SetName("GraphQL document with no query definition returns expected result.");
+
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument
+                {
+                    Definitions = new List<ASTNode>
+                    {
+                        new GraphQLObjectTypeDefinition
+                        {
+                            Name = new GraphQLName(GraphQLToken.Query)
+                        }
+                    }
+                }),
+                new GraphQLObjectTypeDefinition
+                {
+                    Name = new GraphQLName(GraphQLToken.Query)
+                }
+            ).SetName("GraphQL document with query definition returns expected result.");
+        }
+    }
+
+    [Test]
+    [TestCaseSource(nameof(GraphQLMutationTypeDefinitionTestCases))]
+    public void GraphQLMutationTypeDefinition_returns_expected_result(
+        IGraphQLDocumentAdapter graphQLDocumentAdapter,
+        GraphQLObjectTypeDefinition? expectedResult
+    ) => graphQLDocumentAdapter
+        .GraphQLMutationTypeDefinition
+        .Should()
+        .BeEquivalentTo(expectedResult);
+
+    private static IEnumerable<TestCaseData> GraphQLMutationTypeDefinitionTestCases
+    {
+        get
+        {
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument()),
+                null
+            ).SetName("GraphQL document with no definitions returns expected result.");
+
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument
+                {
+                    Definitions = new List<ASTNode>
+                    {
+                        new GraphQLInterfaceTypeDefinition
+                        {
+                            Name = new GraphQLName("SomeInterfaceType")
+                        }
+                    }
+                }),
+                null
+            ).SetName("GraphQL document with no mutation definition returns expected result.");
+
+            yield return new TestCaseData(
+                new GraphQLDocumentAdapter(new GraphQLDocument
+                {
+                    Definitions = new List<ASTNode>
+                    {
+                        new GraphQLObjectTypeDefinition
+                        {
+                            Name = new GraphQLName(GraphQLToken.Mutation)
+                        }
+                    }
+                }),
+                new GraphQLObjectTypeDefinition
+                {
+                    Name = new GraphQLName(GraphQLToken.Mutation)
+                }
+            ).SetName("GraphQL document with mutation definition returns expected result.");
         }
     }
 }

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLCustomScalarTypeConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLCustomScalarTypeConverterTests.cs
@@ -50,7 +50,7 @@ internal sealed class GraphQLCustomScalarTypeConverterTests
         KarateTypeBase expectedKarateType)
     {
         // arrange
-        var shouldCallUnderlyingGraphQLTypeConverter = !_customScalarMapping!.TryGetKarateType(graphQLType.GetTypeName(), out _);
+        var shouldCallUnderlyingGraphQLTypeConverter = !_customScalarMapping!.TryGetKarateType(graphQLType.GetUnwrappedTypeName(), out _);
 
         if (shouldCallUnderlyingGraphQLTypeConverter)
         {

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLToKarateConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLToKarateConverterTests.cs
@@ -77,7 +77,7 @@ internal sealed class GraphQLToKarateConverterTests
             .Returns(ExpectedKarateFeature)
             .AndDoes(ForceEnumerationOfMockedEnumerables);
 
-        var settings = new GraphQLToKarateConverterSettings
+        var settings = new GraphQLToKarateSettings
         {
             QueryName = GraphQLToken.Query,
             ExcludeQueries = false,
@@ -167,7 +167,7 @@ internal sealed class GraphQLToKarateConverterTests
             .Returns(ExpectedKarateFeature)
             .AndDoes(ForceEnumerationOfMockedEnumerables);
 
-        var settings = new GraphQLToKarateConverterSettings
+        var settings = new GraphQLToKarateSettings
         {
             ExcludeQueries = false,
             QueryName = GraphQLToken.Query,
@@ -260,7 +260,7 @@ internal sealed class GraphQLToKarateConverterTests
             .Returns(ExpectedKarateFeature)
             .AndDoes(ForceEnumerationOfMockedEnumerables);
 
-        var settings = new GraphQLToKarateConverterSettings
+        var settings = new GraphQLToKarateSettings
         {
             QueryName = GraphQLToken.Query,
             TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -348,7 +348,7 @@ internal sealed class GraphQLToKarateConverterTests
             .Returns(ExpectedKarateFeature)
             .AndDoes(ForceEnumerationOfMockedEnumerables);
 
-        var settings = new GraphQLToKarateConverterSettings
+        var settings = new GraphQLToKarateSettings
         {
             QueryName = GraphQLToken.Query,
             TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase),
@@ -437,7 +437,7 @@ internal sealed class GraphQLToKarateConverterTests
             .Returns(ExpectedKarateFeature)
             .AndDoes(ForceEnumerationOfMockedEnumerables);
 
-        var settings = new GraphQLToKarateConverterSettings
+        var settings = new GraphQLToKarateSettings
         {
             QueryName = GraphQLToken.Query,
             TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase),
@@ -513,7 +513,7 @@ internal sealed class GraphQLToKarateConverterTests
             .Returns(ExpectedKarateFeature)
             .AndDoes(ForceEnumerationOfMockedEnumerables);
 
-        var settings = new GraphQLToKarateConverterSettings
+        var settings = new GraphQLToKarateSettings
         {
             QueryName = "SomeWackyQueryName",
             TypeFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase),

--- a/tests/GraphQLToKarate.Tests/Extensions/GraphQLTypeExtensionsTests.cs
+++ b/tests/GraphQLToKarate.Tests/Extensions/GraphQLTypeExtensionsTests.cs
@@ -11,10 +11,10 @@ namespace GraphQLToKarate.Tests.Extensions;
 internal sealed class GraphQLTypeExtensionsTests
 {
     [TestCaseSource(nameof(TestCases))]
-    public void GetTypeName_should_return_correct_type_name(
+    public void GetUnwrappedTypeName_should_return_correct_type_name(
         GraphQLType graphQLType,
         string expectedTypeName
-    ) => graphQLType.GetTypeName().Should().Be(expectedTypeName);
+    ) => graphQLType.GetUnwrappedTypeName().Should().Be(expectedTypeName);
 
     private static IEnumerable<TestCaseData> TestCases
     {
@@ -59,13 +59,13 @@ internal sealed class GraphQLTypeExtensionsTests
     }
 
     [Test]
-    public void GetTypeName_should_throw_an_exception_when_unsupported_graphql_type_is_encountered()
+    public void GetUnwrappedTypeName_should_throw_an_exception_when_unsupported_graphql_type_is_encountered()
     {
         // arrange
         var graphQLType = new UnsupportedGraphQLType();
 
         // act
-        var act = () => graphQLType.GetTypeName();
+        var act = () => graphQLType.GetUnwrappedTypeName();
 
         // assert
         act.Should().ThrowExactly<InvalidGraphQLTypeException>();
@@ -85,5 +85,48 @@ internal sealed class GraphQLTypeExtensionsTests
 
         // assert
         result.Should().Be("NamedType");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(IsListTypeTestCases))]
+    public void IsListType_returns_expected_value(GraphQLType graphQLType, bool expectedIsListType) =>
+        graphQLType.IsListType().Should().Be(expectedIsListType);
+
+    private static IEnumerable<TestCaseData> IsListTypeTestCases
+    {
+        get
+        {
+            yield return new TestCaseData(
+                new GraphQLNamedType(),
+                false
+            );
+
+            yield return new TestCaseData(
+                new GraphQLNonNullType
+                {
+                    Type = new GraphQLNamedType()
+                },
+                false
+            );
+
+            yield return new TestCaseData(
+                new GraphQLListType
+                {
+                    Type = new GraphQLNamedType()
+                },
+                true
+            );
+
+            yield return new TestCaseData(
+                new GraphQLNonNullType
+                {
+                    Type = new GraphQLListType
+                    {
+                        Type = new GraphQLNamedType()
+                    }
+                },
+                true
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description

Cleanup:

- Added `IsListType` extension method for convenient checks for list-ness
- Moved remaining GraphQL document parsing to `GraphQLDocumentAdapter`

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
