### PR TITLE
Bugfix for Custom Scalar Mapping Loader

### DIFF
--- a/src/GraphQLToKarate.Library/Converters/GraphQLToKarateConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLToKarateConverter.cs
@@ -89,6 +89,7 @@ public sealed class GraphQLToKarateConverter : IGraphQLToKarateConverter
             graphQLOperations = graphQLOperations.Concat(graphQLQueryOperations).ToList();
         }
 
+        // ReSharper disable once InvertIf
         if (_graphQLToKarateSettings.IncludeMutations)
         {
             var graphQLMutationOperations = graphQLDocumentAdapter.GraphQLMutationTypeDefinition?.Fields?

--- a/src/GraphQLToKarate.Library/Mappings/CustomScalarMappingLoader.cs
+++ b/src/GraphQLToKarate.Library/Mappings/CustomScalarMappingLoader.cs
@@ -8,7 +8,7 @@ namespace GraphQLToKarate.Library.Mappings;
 /// <inheritdoc cref="ICustomScalarMappingLoader"/>
 public sealed class CustomScalarMappingLoader : ICustomScalarMappingLoader
 {
-    private readonly Regex _regex = new(@"^([\w\s]+:[\w\s]+,\s*)+[\w\s]+:[\w\s]+$", RegexOptions.Compiled);
+    private readonly Regex _regex = new(@"^([\w\s]+:[\w\s]+(?:,\s*|$))*[\w\s]+:[\w\s]+(?:,\s*)?$", RegexOptions.Compiled);
     private readonly IFile _file;
 
     public CustomScalarMappingLoader(IFile file) => _file = file;

--- a/tests/GraphQLToKarate.Tests/Adapters/GraphQLDocumentAdapterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Adapters/GraphQLDocumentAdapterTests.cs
@@ -656,7 +656,7 @@ internal sealed class GraphQLDocumentAdapterTests
                 null
             ).SetName("When GraphQL document is empty, enum type definition is not found");
 
-            var graphQLEnumTypeDefinitionName = "Color";
+            const string graphQLEnumTypeDefinitionName = "Color";
 
             var graphQLEnumTypeDefinition = new GraphQLEnumTypeDefinition
             {


### PR DESCRIPTION
## Description

- Bugfix for `CustomScalarMappingLoader` to allow for a single mapping (no trailing comma) by fixing the regex involved.
- New test coverage to catch previous bug.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
