### PR TITLE
Custom Scalar Mapping Refactor

### DIFF
--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
@@ -82,16 +82,11 @@ internal sealed class ConvertCommandSettings : LogCommandSettings
         }
 
         // ReSharper disable once ConvertIfStatementToReturnStatement
-        if (!IsCustomScalarMappingValid(CustomScalarMapping))
+        if (!_customScalarMappingValidator.IsValid(CustomScalarMapping))
         {
             return ValidationResult.Error("The --custom-scalar-mapping option value is invalid. Please provide either a valid file path or valid custom scalar mapping value.");
         }
 
         return ValidationResult.Success();
     }
-
-    private bool IsCustomScalarMappingValid(string? customScalarMapping) =>
-        string.IsNullOrEmpty(customScalarMapping) ||
-        _customScalarMappingValidator.IsTextLoadable(customScalarMapping) ||
-        _customScalarMappingValidator.IsFileLoadable(customScalarMapping);
 }

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
@@ -19,7 +19,7 @@ internal sealed class ConvertCommandSettingsLoader : IConvertCommandSettingsLoad
     public async Task<LoadedConvertCommandSettings> LoadAsync(ConvertCommandSettings convertCommandSettings)
     {
         var graphQLSchema = await _file.ReadAllTextAsync(convertCommandSettings.InputFile!).ConfigureAwait(false);
-        var customScalarMapping = await LoadCustomScalarMappingAsync(convertCommandSettings).ConfigureAwait(false);
+        var customScalarMapping = await _customScalarMappingLoader.LoadAsync(convertCommandSettings.CustomScalarMapping).ConfigureAwait(false);
 
         return new LoadedConvertCommandSettings
         {
@@ -34,26 +34,5 @@ internal sealed class ConvertCommandSettingsLoader : IConvertCommandSettingsLoad
             TypeFilter = convertCommandSettings.TypeFilter,
             OperationFilter = convertCommandSettings.OperationFilter
         };
-    }
-
-    private async Task<ICustomScalarMapping> LoadCustomScalarMappingAsync(
-        ConvertCommandSettings convertCommandSettings)
-    {
-        if (convertCommandSettings.CustomScalarMapping is null)
-        {
-            return new CustomScalarMapping();
-        }
-
-        if (_customScalarMappingLoader.IsTextLoadable(convertCommandSettings.CustomScalarMapping!))
-        {
-            return _customScalarMappingLoader.LoadFromText(convertCommandSettings.CustomScalarMapping!);
-        }
-
-        if (_customScalarMappingLoader.IsFileLoadable(convertCommandSettings.CustomScalarMapping!))
-        {
-            return await _customScalarMappingLoader.LoadFromFileAsync(convertCommandSettings.CustomScalarMapping!).ConfigureAwait(false);
-        }
-
-        return new CustomScalarMapping();
     }
 }

--- a/src/GraphQLToKarate.Library/Mappings/CustomScalarMappingLoader.cs
+++ b/src/GraphQLToKarate.Library/Mappings/CustomScalarMappingLoader.cs
@@ -74,6 +74,4 @@ public sealed class CustomScalarMappingLoader : ICustomScalarMappingLoader
                 customScalarMappingEntryParts => customScalarMappingEntryParts.Last()
             )
     );
-
-
 }

--- a/src/GraphQLToKarate.Library/Mappings/CustomScalarMappingLoader.cs
+++ b/src/GraphQLToKarate.Library/Mappings/CustomScalarMappingLoader.cs
@@ -13,6 +13,19 @@ public sealed class CustomScalarMappingLoader : ICustomScalarMappingLoader
 
     public CustomScalarMappingLoader(IFile file) => _file = file;
 
+    public async Task<ICustomScalarMapping> LoadAsync(string? customScalarMappingSource) => customScalarMappingSource switch
+    {
+        null => new CustomScalarMapping(),
+        _ when IsTextLoadable(customScalarMappingSource) => LoadFromText(customScalarMappingSource),
+        _ when IsFileLoadable(customScalarMappingSource) => await LoadFromFileAsync(customScalarMappingSource).ConfigureAwait(false),
+        _ => new CustomScalarMapping()
+    };
+
+    public bool IsValid(string? customScalarMappingSource) =>
+        string.IsNullOrEmpty(customScalarMappingSource) ||
+        IsTextLoadable(customScalarMappingSource) ||
+        IsFileLoadable(customScalarMappingSource);
+    
     public bool IsFileLoadable(string filePath)
     {
         if (!_file.Exists(filePath))
@@ -24,7 +37,7 @@ public sealed class CustomScalarMappingLoader : ICustomScalarMappingLoader
 
         if (string.IsNullOrWhiteSpace(fileContent))
         {
-            return false;
+            return true;
         }
 
         if (_regex.IsMatch(fileContent))
@@ -46,9 +59,6 @@ public sealed class CustomScalarMappingLoader : ICustomScalarMappingLoader
 
     public bool IsTextLoadable(string text) => _regex.IsMatch(text);
 
-    public ICustomScalarMapping LoadFromFile(string filePath) =>
-        DeserializeFileContent(_file.ReadAllText(filePath));
-
     public async Task<ICustomScalarMapping> LoadFromFileAsync(string filePath) =>
         DeserializeFileContent(await _file.ReadAllTextAsync(filePath));
 
@@ -64,4 +74,6 @@ public sealed class CustomScalarMappingLoader : ICustomScalarMappingLoader
                 customScalarMappingEntryParts => customScalarMappingEntryParts.Last()
             )
     );
+
+
 }

--- a/src/GraphQLToKarate.Library/Mappings/ICustomScalarMappingLoader.cs
+++ b/src/GraphQLToKarate.Library/Mappings/ICustomScalarMappingLoader.cs
@@ -7,23 +7,9 @@
 public interface ICustomScalarMappingLoader : ICustomScalarMappingValidator
 {
     /// <summary>
-    ///     Load the custom scalar mapping from the given file path.
+    ///     Load the custom scalar mapping from the given source (file path or raw text).
     /// </summary>
-    /// <param name="filePath">The file path to load the custom scalar mapping from.</param>
+    /// <param name="customScalarMappingSource">The custom scalar mapping source (file path or raw text) to load the custom scalar mapping from.</param>
     /// <returns>The custom scalar mapping.</returns>
-    ICustomScalarMapping LoadFromFile(string filePath);
-
-    /// <summary>
-    ///     Load the custom scalar mapping from the given file path.
-    /// </summary>
-    /// <param name="filePath">The file path to load the custom scalar mapping from.</param>
-    /// <returns>The custom scalar mapping.</returns>
-    Task<ICustomScalarMapping> LoadFromFileAsync(string filePath);
-
-    /// <summary>
-    ///     Load the custom scalar mapping from the given text.
-    /// </summary>
-    /// <param name="text">The text to load the custom scalar mapping from.</param>
-    /// <returns>The custom scalar mapping.</returns>
-    ICustomScalarMapping LoadFromText(string text);
+    Task<ICustomScalarMapping> LoadAsync(string? customScalarMappingSource);
 }

--- a/src/GraphQLToKarate.Library/Mappings/ICustomScalarMappingValidator.cs
+++ b/src/GraphQLToKarate.Library/Mappings/ICustomScalarMappingValidator.cs
@@ -6,16 +6,9 @@
 public interface ICustomScalarMappingValidator
 {
     /// <summary>
-    ///     Returns whether the custom scalar mapping is loadable from a file.
+    ///     Returns whether the custom scalar mapping source (file path or raw text) is valid.
     /// </summary>
-    /// <param name="filePath">The file path to check.</param>
-    /// <returns>Whether or not the custom scalar mapping is loadable from the given file path.</returns>
-    bool IsFileLoadable(string filePath);
-
-    /// <summary>
-    ///     Returns whether the custom scalar mapping is loadable from a given text.
-    /// </summary>
-    /// <param name="text">The text to check.</param>
-    /// <returns>Whether or not the custom scalar mapping is loadable form the given text.</returns>
-    bool IsTextLoadable(string text);
+    /// <param name="customScalarMappingSource">The custom scalar mapping source (file path or raw text) to check.</param>
+    /// <returns>Whether or not the custom scalar mapping source (file path or raw text) is valid.</returns>
+    bool IsValid(string? customScalarMappingSource);
 }

--- a/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
@@ -63,6 +63,10 @@ internal sealed class CommandAppConfiguratorTests
             .Build()
             .Returns(_mockTypeResolver);
 
+        _mockCustomScalarMappingValidator!
+            .IsValid(Arg.Any<string>())
+            .Returns(true);
+
         _mockConvertCommandSettingsLoader!
             .LoadAsync(Arg.Any<ConvertCommandSettings>())
             .Returns(new LoadedConvertCommandSettings

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
@@ -107,25 +107,8 @@ internal sealed class ConvertCommandSettingsLoaderTests
         );
 
         _mockCustomScalarMappingLoader!
-            .IsFileLoadable(convertCommandSettings.CustomScalarMapping)
-            .Returns(mockCustomScalarMappingLoaderIsFileLoadableReturn);
-
-        _mockCustomScalarMappingLoader
-            .IsTextLoadable(convertCommandSettings.CustomScalarMapping)
-            .Returns(!mockCustomScalarMappingLoaderIsFileLoadableReturn);
-
-        if (mockCustomScalarMappingLoaderIsFileLoadableReturn)
-        {
-            _mockCustomScalarMappingLoader
-                .LoadFromFileAsync(convertCommandSettings.CustomScalarMapping)
-                .Returns(expectedCustomScalarMapping);
-        }
-        else
-        {
-            _mockCustomScalarMappingLoader
-                .LoadFromText(convertCommandSettings.CustomScalarMapping)
-                .Returns(expectedCustomScalarMapping);
-        }
+            .LoadAsync(convertCommandSettings.CustomScalarMapping)
+            .Returns(expectedCustomScalarMapping);
 
         // act
         var loadedConvertCommandSettings = await _subjectUnderTest!.LoadAsync(convertCommandSettings);
@@ -160,6 +143,10 @@ internal sealed class ConvertCommandSettingsLoaderTests
             .ReadAllTextAsync(convertCommandSettings.InputFile)
             .Returns(SomeGraphQLSchema);
 
+        _mockCustomScalarMappingLoader!
+            .LoadAsync(convertCommandSettings.CustomScalarMapping)
+            .Returns(new CustomScalarMapping());
+
         var expectedCustomScalarMapping = new CustomScalarMapping();
 
         // act
@@ -193,12 +180,8 @@ internal sealed class ConvertCommandSettingsLoaderTests
             .Returns(SomeGraphQLSchema);
 
         _mockCustomScalarMappingLoader!
-            .IsFileLoadable(convertCommandSettings.CustomScalarMapping)
-            .Returns(false);
-
-        _mockCustomScalarMappingLoader!
-            .IsTextLoadable(convertCommandSettings.CustomScalarMapping)
-            .Returns(false);
+            .LoadAsync(convertCommandSettings.CustomScalarMapping)
+            .Returns(new CustomScalarMapping());
 
         var expectedCustomScalarMapping = new CustomScalarMapping();
 

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsTests.cs
@@ -32,11 +32,7 @@ internal sealed class ConvertCommandSettingsTests
         _mockFile!.Exists(graphQLSchemaFile).Returns(graphQLSchemaFileExistsReturn);
 
         _mockCustomScalarMappingValidator!
-            .IsFileLoadable(customScalarMapping!)
-            .Returns(customScalarMappingValidatorReturn);
-
-        _mockCustomScalarMappingValidator!
-            .IsTextLoadable(customScalarMapping!)
+            .IsValid(customScalarMapping)
             .Returns(customScalarMappingValidatorReturn);
 
         var settings = new ConvertCommandSettings(_mockFile, _mockCustomScalarMappingValidator!)
@@ -100,7 +96,7 @@ internal sealed class ConvertCommandSettingsTests
                 "schema.graphql",
                 null,
                 true,
-                false,
+                true,
                 null
             ).SetName("When non-null and non-empty InputFile name points to file that exists, settings are valid (null custom scalar mapping).");
 
@@ -108,7 +104,7 @@ internal sealed class ConvertCommandSettingsTests
                 "schema.graphql",
                 string.Empty,
                 true,
-                false,
+                true,
                 null
             ).SetName("When non-null and non-empty InputFile name points to file that exists, settings are valid (empty custom scalar mapping).");
 

--- a/tests/GraphQLToKarate.Tests/Mappings/CustomScalarMappingLoaderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Mappings/CustomScalarMappingLoaderTests.cs
@@ -92,6 +92,18 @@ internal sealed class CustomScalarMappingLoaderTests
     }
 
     [Test]
+    [TestCase(null)]
+    [TestCase("invalid")]
+    public async Task LoadAsync_returns_empty_custom_scalar_mapping_when_given_invalid_input(string invalidInput)
+    {
+        // act
+        var customScalarMapping = await _subjectUnderTest!.LoadAsync(invalidInput);
+
+        // assert
+        customScalarMapping.Should().BeEquivalentTo(new CustomScalarMapping());
+    }
+
+    [Test]
     [TestCaseSource(nameof(LoadFromFileTestCases))]
     public async Task LoadAsync_returns_expected_result_when_file_exists_and_contains_expected_content(
         string fileContent,

--- a/tests/GraphQLToKarate.Tests/Mappings/CustomScalarMappingLoaderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Mappings/CustomScalarMappingLoaderTests.cs
@@ -33,7 +33,7 @@ internal sealed class CustomScalarMappingLoaderTests
     private const string CustomScalarMappingAsShortText = "DateTime:string";
 
     [Test]
-    public void IsFileLoadable_returns_false_when_file_does_not_exist()
+    public void IsValid_returns_false_when_file_does_not_exist()
     {
         // arrange
         _mockFile!
@@ -41,22 +41,22 @@ internal sealed class CustomScalarMappingLoaderTests
             .Returns(false);
 
         // act
-        var isFileLoadable = _subjectUnderTest!.IsFileLoadable("some-file-path");
+        var isValid = _subjectUnderTest!.IsValid("some-file-path");
 
         // assert
-        isFileLoadable.Should().BeFalse();
+        isValid.Should().BeFalse();
     }
 
     [Test]
-    [TestCase("", false)]
     [TestCase("  : ,  : , :", false)]
     [TestCase("some random text xyz {123}", false)]
+    [TestCase("", true)]
     [TestCase(CustomScalarMappingAsJson, true)]
     [TestCase(CustomScalarMappingAsText, true)]
     [TestCase(CustomScalarMappingAsShortText, true)]
-    public void IsFileLoadable_returns_expected_result_based_on_file_content(
+    public void IsValid_returns_expected_result_based_on_file_content(
         string fileContent,
-        bool expectedIsFileLoadable)
+        bool expectedIsValid)
     {
         // arrange
         _mockFile!
@@ -68,54 +68,32 @@ internal sealed class CustomScalarMappingLoaderTests
             .Returns(fileContent);
 
         // act
-        var isFileLoadable = _subjectUnderTest!.IsFileLoadable("some-file-path");
+        var isValid = _subjectUnderTest!.IsValid("some-file-path");
 
         // assert
-        isFileLoadable.Should().Be(expectedIsFileLoadable);
+        isValid.Should().Be(expectedIsValid);
     }
 
     [Test]
-    [TestCase("", false)]
     [TestCase("  : ,  : , :", false)]
     [TestCase("some,random,text", false)]
+    [TestCase("", true)]
     [TestCase(CustomScalarMappingAsText, true)]
     [TestCase(CustomScalarMappingAsShortText, true)]
-    public void IsTextLoadable_returns_expected_result_based_on_text_content(
+    public void IsValid_returns_expected_result_based_on_text_content(
         string textContent,
-        bool expectedIsTextLoadable)
+        bool expectedIsValid)
     {
         // act
-        var result = _subjectUnderTest!.IsTextLoadable(textContent);
+        var result = _subjectUnderTest!.IsValid(textContent);
 
         // assert
-        result.Should().Be(expectedIsTextLoadable);
+        result.Should().Be(expectedIsValid);
     }
 
     [Test]
     [TestCaseSource(nameof(LoadFromFileTestCases))]
-    public void LoadFromFile_returns_expected_result_when_file_exists_and_contains_expected_content(
-        string fileContent,
-        CustomScalarMapping expectedCustomScalarMapping)
-    {
-        // arrange
-        _mockFile!
-            .Exists(Arg.Any<string>())
-            .Returns(true);
-
-        _mockFile!
-            .ReadAllText(Arg.Any<string>())
-            .Returns(fileContent);
-
-        // act
-        var customScalarMapping = _subjectUnderTest!.LoadFromFile("some-file-path");
-
-        // assert
-        customScalarMapping.Should().BeEquivalentTo(expectedCustomScalarMapping);
-    }
-
-    [Test]
-    [TestCaseSource(nameof(LoadFromFileTestCases))]
-    public async Task LoadFromFileAsync_returns_expected_result_when_file_exists_and_contains_expected_content(
+    public async Task LoadAsync_returns_expected_result_when_file_exists_and_contains_expected_content(
         string fileContent,
         CustomScalarMapping expectedCustomScalarMapping)
     {
@@ -129,7 +107,7 @@ internal sealed class CustomScalarMappingLoaderTests
             .Returns(fileContent);
 
         // act
-        var customScalarMapping = await _subjectUnderTest!.LoadFromFileAsync("some-file-path");
+        var customScalarMapping = await _subjectUnderTest!.LoadAsync("some-file-path");
 
         // assert
         customScalarMapping.Should().BeEquivalentTo(expectedCustomScalarMapping);
@@ -137,12 +115,12 @@ internal sealed class CustomScalarMappingLoaderTests
 
     [Test]
     [TestCaseSource(nameof(LoadFromTextTestCases))]
-    public void LoadFromText_returns_expected_result_when_text_contains_expected_content(
+    public async Task LoadAsync_returns_expected_result_when_text_contains_expected_content(
         string textContent,
         CustomScalarMapping expectedCustomScalarMapping)
     {
         // act
-        var customScalarMapping = _subjectUnderTest!.LoadFromText(textContent);
+        var customScalarMapping = await _subjectUnderTest!.LoadAsync(textContent);
 
         // assert
         customScalarMapping.Should().BeEquivalentTo(expectedCustomScalarMapping);


### PR DESCRIPTION
## Description

Refactor custom scalar mapping handling:

- Simplify validation and only expose a single `IsValid` method
  - Consider a null/whitespace to be valid since it can just produce an empty CSM
- Simplify loading in the custom scalar mapping and only expose a single `LoadAsync` method

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
