### PR TITLE
Display Option Output

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -39,7 +39,7 @@ dotnet_diagnostic.SA1633.severity = none
 dotnet_diagnostic.SA1642.severity = none
 
 # max method length
-MA0051.maximum_lines_per_method = 80
+MA0051.maximum_lines_per_method = 120
 
 [*Tests.cs]
 

--- a/src/GraphQLToKarate.CommandLine/Prompts/ConvertCommandSettingsPrompt.cs
+++ b/src/GraphQLToKarate.CommandLine/Prompts/ConvertCommandSettingsPrompt.cs
@@ -95,9 +95,7 @@ internal class ConvertCommandSettingsPrompt : IConvertCommandSettingsPrompt
         var mutationOperationFilter = PromptForMutationOperationFilter(graphQLDocumentAdapter, includeMutations);
         var graphQLTypeFilter = PromptForTypeFilter(graphQLDocumentAdapter);
 
-        _ansiConsole.Write(new Padder(new Rule { Style = InfoStyle }.DoubleBorder()).PadLeft(1).PadRight(1));
-
-        return new LoadedConvertCommandSettings
+        var loadedConvertCommandSettings = new LoadedConvertCommandSettings
         {
             GraphQLSchema = initialLoadedConvertCommandSettings.GraphQLSchema,
             QueryName = queryName,
@@ -111,6 +109,49 @@ internal class ConvertCommandSettingsPrompt : IConvertCommandSettingsPrompt
             CustomScalarMapping = customScalarMapping,
             OutputFile = outputFile
         };
+
+        WriteCapturedOptions(loadedConvertCommandSettings);
+
+        return loadedConvertCommandSettings;
+    }
+
+    private void WriteCapturedOptions(LoadedConvertCommandSettings loadedConvertCommandSettings)
+    {
+        var table = new Table()
+            .Title("[bold underline]Captured Options[/]")
+            .Border(TableBorder.DoubleEdge)
+            .BorderColor(InfoColor)
+            .HideHeaders()
+            .AddColumn(new TableColumn("[bold underline]Option[/]"))
+            .AddColumn(new TableColumn("[bold underline]Value[/]"))
+            .AddRow($"[{InstructionsColorRgb}]--output-file[/]", loadedConvertCommandSettings.OutputFile)
+            .AddRow($"[{InstructionsColorRgb}]--query-name[/]", loadedConvertCommandSettings.QueryName)
+            .AddRow($"[{InstructionsColorRgb}]--mutation-name[/]", loadedConvertCommandSettings.MutationName)
+            .AddRow($"[{InstructionsColorRgb}]--exclude-queries[/]", loadedConvertCommandSettings.ExcludeQueries.ToString())
+            .AddRow($"[{InstructionsColorRgb}]--include-mutations[/]", loadedConvertCommandSettings.IncludeMutations.ToString())
+            .AddRow($"[{InstructionsColorRgb}]--base-url[/]", loadedConvertCommandSettings.BaseUrl);
+
+        if (loadedConvertCommandSettings.CustomScalarMapping.Any())
+        {
+            table.AddRow($"[{InstructionsColorRgb}]--custom-scalar-mapping[/]", string.Join(',', loadedConvertCommandSettings.CustomScalarMapping));
+        }
+
+        if (loadedConvertCommandSettings.QueryOperationFilter.Any())
+        {
+            table.AddRow($"[{InstructionsColorRgb}]--query-operation-filter[/]", string.Join(',', loadedConvertCommandSettings.QueryOperationFilter));
+        }
+
+        if (loadedConvertCommandSettings.MutationOperationFilter.Any())
+        {
+            table.AddRow($"[{InstructionsColorRgb}]--mutation-operation-filter[/]", string.Join(',', loadedConvertCommandSettings.MutationOperationFilter));
+        }
+
+        if (loadedConvertCommandSettings.TypeFilter.Any())
+        {
+            table.AddRow($"[{InstructionsColorRgb}]--type-filter[/]", string.Join(',', loadedConvertCommandSettings.TypeFilter));
+        }
+
+        _ansiConsole.Write(new Padder(table).PadLeft(1).PadRight(1));
     }
 
     private string PromptForOutputFile(LoadedConvertCommandSettings initialLoadedConvertCommandSettings) =>

--- a/src/GraphQLToKarate.Library/Mappings/CustomScalarMapping.cs
+++ b/src/GraphQLToKarate.Library/Mappings/CustomScalarMapping.cs
@@ -1,4 +1,6 @@
-﻿namespace GraphQLToKarate.Library.Mappings;
+﻿using System.Text;
+
+namespace GraphQLToKarate.Library.Mappings;
 
 /// <inheritdoc cref="ICustomScalarMapping"/>
 public sealed class CustomScalarMapping : ICustomScalarMapping
@@ -14,4 +16,12 @@ public sealed class CustomScalarMapping : ICustomScalarMapping
         Mappings.TryGetValue(graphQLType, out karateType!);
 
     public bool Any() => Mappings.Any();
+
+    /// <summary>
+    ///     Returns the custom scalar mapping as a string, formatted in a way that is acceptable as a command-line argument.
+    ///
+    ///     An example response would be "DateTime:string,URL:string,Long:int".
+    /// </summary>
+    /// <returns>The custom scalar mapping as a string.</returns>
+    public override string ToString() => string.Join(',', Mappings.Select(mapping => $"{mapping.Key}:{mapping.Value}"));
 }

--- a/tests/GraphQLToKarate.Tests/Mappings/CustomScalarMappingTest.cs
+++ b/tests/GraphQLToKarate.Tests/Mappings/CustomScalarMappingTest.cs
@@ -10,7 +10,9 @@ public class CustomScalarMappingTests
     [TestCase("String", "string")]
     [TestCase("Int", "int")]
     [TestCase("Boolean", "boolean")]
-    public void TryGetKarateType_should_return_true_and_karate_type_when_mapping_exists(string graphQLType, string expectedKarateType)
+    public void TryGetKarateType_should_return_true_and_karate_type_when_mapping_exists(
+        string graphQLType,
+        string expectedKarateType)
     {
         // arrange
         var customScalarMapping = new CustomScalarMapping(
@@ -33,7 +35,8 @@ public class CustomScalarMappingTests
 
     [TestCase("Float")]
     [TestCase("ID")]
-    public void TryGetKarateType_should_return_false_and_null_karate_type_when_mapping_does_not_exist(string graphQLType)
+    public void TryGetKarateType_should_return_false_and_null_karate_type_when_mapping_does_not_exist(
+        string graphQLType)
     {
         // arrange
         var customScalarMapping = new CustomScalarMapping(
@@ -52,5 +55,25 @@ public class CustomScalarMappingTests
         customScalarMapping.Any().Should().BeTrue();
         result.Should().BeFalse();
         karateType.Should().BeNull();
+    }
+
+    [Test]
+    public void ToString_generates_expected_string()
+    {
+        // arrange
+        var customScalarMapping = new CustomScalarMapping(
+            new Dictionary<string, string>
+            {
+                { "String", "string" },
+                { "Int", "int" },
+                { "Boolean", "boolean" }
+            }
+        );
+
+        // act
+        var result = customScalarMapping.ToString();
+
+        // assert
+        result.Should().Be("String:string,Int:int,Boolean:boolean");
     }
 }


### PR DESCRIPTION
## Description

Display the user's option values before running conversion:

![image](https://user-images.githubusercontent.com/45316999/225179661-790779e8-245b-4aba-b01c-b931af7a59fb.png)

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
