### PR TITLE
Display Non-Interactive Command

### DIFF
--- a/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
+++ b/src/GraphQLToKarate.CommandLine/Commands/ConvertCommand.cs
@@ -33,7 +33,7 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommandSettings>
     {
         var loadedCommandSettings = await _convertCommandSettingsLoader.LoadAsync(commandSettings).ConfigureAwait(false);
 
-        if (commandSettings.IsInteractive)
+        if (!commandSettings.IsNonInteractive)
         {
             loadedCommandSettings = await _convertCommandSettingsPrompt.PromptAsync(loadedCommandSettings).ConfigureAwait(false);
         }

--- a/src/GraphQLToKarate.CommandLine/Prompts/ConvertCommandSettingsPrompt.cs
+++ b/src/GraphQLToKarate.CommandLine/Prompts/ConvertCommandSettingsPrompt.cs
@@ -53,34 +53,32 @@ internal class ConvertCommandSettingsPrompt : IConvertCommandSettingsPrompt
 
         if (!_ansiConsole.Profile.Capabilities.Interactive)
         {
-            _ansiConsole.MarkupLine($"[{ErrorColorRgb}]Current environment does not support interaction.[/] Continuing with default settings. Use a console which supports interaction or use the [{InstructionsColorRgb}]--interactive=false[/] option to specify settings.");
+            _ansiConsole.MarkupLine($"[{ErrorColorRgb}]Current environment does not support interaction.[/] Continuing with default settings. Use a console which supports interaction or use the [{InstructionsColorRgb}]{Options.NonInteractiveOptionName}[/] option to specify settings.");
             _ansiConsole.Write(new Padder(new Rule { Style = InfoStyle }).PadLeft(1).PadRight(1));
 
             return initialLoadedConvertCommandSettings;
         }
 
-        void Newline() => _ansiConsole.WriteLine();
-
         var outputFile = PromptForOutputFile(initialLoadedConvertCommandSettings);
-        Newline();
+        _ansiConsole.WriteLine();
 
         var queryName = PromptForQueryName(initialLoadedConvertCommandSettings);
-        Newline();
+        _ansiConsole.WriteLine();
 
         var mutationName = PromptForMutationName(initialLoadedConvertCommandSettings);
-        Newline();
+        _ansiConsole.WriteLine();
 
         var excludeQueries = PromptForExcludeQueriesChoice(initialLoadedConvertCommandSettings);
-        Newline();
+        _ansiConsole.WriteLine();
 
         var includeMutations = PromptForIncludeMutationsChoice(initialLoadedConvertCommandSettings);
-        Newline();
+        _ansiConsole.WriteLine();
 
         var baseUrl = PromptForBaseUrl(initialLoadedConvertCommandSettings);
-        Newline();
+        _ansiConsole.WriteLine();
 
         var customScalarMapping = await PromptForCustomScalarMappingAsync().ConfigureAwait(false);
-        Newline();
+        _ansiConsole.WriteLine();
 
         var graphQLDocumentAdapter = new GraphQLDocumentAdapter(
             _graphQLSchemaParser.Parse(initialLoadedConvertCommandSettings.GraphQLSchema),
@@ -98,19 +96,23 @@ internal class ConvertCommandSettingsPrompt : IConvertCommandSettingsPrompt
         var loadedConvertCommandSettings = new LoadedConvertCommandSettings
         {
             GraphQLSchema = initialLoadedConvertCommandSettings.GraphQLSchema,
+            InputFile = initialLoadedConvertCommandSettings.InputFile,
+            OutputFile = outputFile,
             QueryName = queryName,
             MutationName = mutationName,
-            BaseUrl = baseUrl,
             ExcludeQueries = excludeQueries,
             IncludeMutations = includeMutations,
+            BaseUrl = baseUrl,
+            CustomScalarMapping = customScalarMapping,
             QueryOperationFilter = queryOperationFilter,
             MutationOperationFilter = mutationOperationFilter,
-            TypeFilter = graphQLTypeFilter,
-            CustomScalarMapping = customScalarMapping,
-            OutputFile = outputFile
+            TypeFilter = graphQLTypeFilter
         };
 
         WriteCapturedOptions(loadedConvertCommandSettings);
+
+        _ansiConsole.MarkupLine($"Non-interactive command: [{InstructionsColorRgb}]{loadedConvertCommandSettings.ToCommandLineCommand()}[/]");
+        _ansiConsole.WriteLine();
 
         return loadedConvertCommandSettings;
     }
@@ -124,31 +126,31 @@ internal class ConvertCommandSettingsPrompt : IConvertCommandSettingsPrompt
             .HideHeaders()
             .AddColumn(new TableColumn("[bold underline]Option[/]"))
             .AddColumn(new TableColumn("[bold underline]Value[/]"))
-            .AddRow($"[{InstructionsColorRgb}]--output-file[/]", loadedConvertCommandSettings.OutputFile)
-            .AddRow($"[{InstructionsColorRgb}]--query-name[/]", loadedConvertCommandSettings.QueryName)
-            .AddRow($"[{InstructionsColorRgb}]--mutation-name[/]", loadedConvertCommandSettings.MutationName)
-            .AddRow($"[{InstructionsColorRgb}]--exclude-queries[/]", loadedConvertCommandSettings.ExcludeQueries.ToString())
-            .AddRow($"[{InstructionsColorRgb}]--include-mutations[/]", loadedConvertCommandSettings.IncludeMutations.ToString())
-            .AddRow($"[{InstructionsColorRgb}]--base-url[/]", loadedConvertCommandSettings.BaseUrl);
+            .AddRow($"[{InstructionsColorRgb}]{Options.OutputFileOptionName}[/]", loadedConvertCommandSettings.OutputFile)
+            .AddRow($"[{InstructionsColorRgb}]{Options.QueryNameOptionName}[/]", loadedConvertCommandSettings.QueryName)
+            .AddRow($"[{InstructionsColorRgb}]{Options.MutationNameOptionName}[/]", loadedConvertCommandSettings.MutationName)
+            .AddRow($"[{InstructionsColorRgb}]{Options.ExcludeQueriesOptionName}[/]", loadedConvertCommandSettings.ExcludeQueries.ToString())
+            .AddRow($"[{InstructionsColorRgb}]{Options.IncludeMutationsOptionName}[/]", loadedConvertCommandSettings.IncludeMutations.ToString())
+            .AddRow($"[{InstructionsColorRgb}]{Options.BaseUrlOptionName}[/]", loadedConvertCommandSettings.BaseUrl);
 
         if (loadedConvertCommandSettings.CustomScalarMapping.Any())
         {
-            table.AddRow($"[{InstructionsColorRgb}]--custom-scalar-mapping[/]", string.Join(',', loadedConvertCommandSettings.CustomScalarMapping));
+            table.AddRow($"[{InstructionsColorRgb}]{Options.CustomScalarMappingOptionName}[/]", string.Join(',', loadedConvertCommandSettings.CustomScalarMapping));
         }
 
         if (loadedConvertCommandSettings.QueryOperationFilter.Any())
         {
-            table.AddRow($"[{InstructionsColorRgb}]--query-operation-filter[/]", string.Join(',', loadedConvertCommandSettings.QueryOperationFilter));
+            table.AddRow($"[{InstructionsColorRgb}]{Options.QueryOperationFilterOptionName}[/]", string.Join(',', loadedConvertCommandSettings.QueryOperationFilter));
         }
 
         if (loadedConvertCommandSettings.MutationOperationFilter.Any())
         {
-            table.AddRow($"[{InstructionsColorRgb}]--mutation-operation-filter[/]", string.Join(',', loadedConvertCommandSettings.MutationOperationFilter));
+            table.AddRow($"[{InstructionsColorRgb}]{Options.MutationOperationFilterOptionName}[/]", string.Join(',', loadedConvertCommandSettings.MutationOperationFilter));
         }
 
         if (loadedConvertCommandSettings.TypeFilter.Any())
         {
-            table.AddRow($"[{InstructionsColorRgb}]--type-filter[/]", string.Join(',', loadedConvertCommandSettings.TypeFilter));
+            table.AddRow($"[{InstructionsColorRgb}]{Options.TypeFilterOptionName}[/]", string.Join(',', loadedConvertCommandSettings.TypeFilter));
         }
 
         _ansiConsole.Write(new Padder(table).PadLeft(1).PadRight(1));

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettings.cs
@@ -1,5 +1,4 @@
 ﻿using GraphQLToKarate.Library.Mappings;
-using GraphQLToKarate.Library.Tokens;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using System.ComponentModel;
@@ -23,62 +22,63 @@ internal sealed class ConvertCommandSettings : LogCommandSettings
     [Description("The path of the GraphQL schema file to convert")]
     public string? InputFile { get; set; }
 
-    [CommandOption("--interactive")]
-    [Description("Whether to run conversion in an interactive way or not")]
-    [DefaultValue(typeof(string), "true")]
-    public bool IsInteractive { get; set; }
+    [CommandOption(Options.NonInteractiveOptionName)]
+    [Description(Options.NonInteractiveOptionDescription)]
+    [DefaultValue(typeof(string), Options.NonInteractiveOptionDefaultAttributeValue)]
+    public bool IsNonInteractive { get; set; } = Options.NonInteractiveOptionDefaultValue;
 
-    [CommandOption("--output-file")]
-    [Description("The path of the output Karate feature file")]
-    [DefaultValue(typeof(string), "graphql.feature")]
-    public string? OutputFile { get; set; }
+    [CommandOption(Options.OutputFileOptionName)]
+    [Description(Options.OutputFileOptionDescription)]
+    [DefaultValue(typeof(string), Options.OutputFileOptionDefaultAttributeValue)]
+    public string? OutputFile { get; set; } = Options.OutputFileOptionDefaultValue;
 
-    [CommandOption("--custom-scalar-mapping")]
-    [Description("The path or string value custom scalar mapping")]
-    public string? CustomScalarMapping { get; set; }
+    [CommandOption(Options.QueryNameOptionName)]
+    [Description(Options.QueryNameOptionDescription)]
+    [DefaultValue(typeof(string), Options.QueryNameOptionDefaultAttributeValue)]
+    public string? QueryName { get; set; } = Options.QueryNameOptionDefaultValue;
 
-    [CommandOption("--exclude-queries")]
-    [Description("Whether to exclude queries or not")]
-    [DefaultValue(typeof(string), "false")]
-    public bool ExcludeQueries { get; set; }
+    [CommandOption(Options.MutationNameOptionName)]
+    [Description(Options.MutationNameOptionDescription)]
+    [DefaultValue(typeof(string), Options.MutationNameOptionDefaultAttributeValue)]
+    public string? MutationName { get; set; } = Options.MutationNameOptionDefaultValue;
 
-    [CommandOption("--include-mutations")]
-    [Description("WHether to include mutations or not")]
-    [DefaultValue(typeof(string), "false")]
-    public bool IncludeMutations { get; set; }
+    [CommandOption(Options.ExcludeQueriesOptionName)]
+    [Description(Options.ExcludeQueriesOptionDescription)]
+    [DefaultValue(typeof(string), Options.ExcludeQueriesOptionDefaultAttributeValue)]
+    public bool ExcludeQueries { get; set; } = Options.ExcludeQueriesOptionDefaultValue;
 
-    [CommandOption("--base-url")]
-    [Description("The base URL to be used in the Karate feature")]
-    [DefaultValue(typeof(string), "baseUrl")]
-    public string? BaseUrl { get; set; } = "baseUrl";
+    [CommandOption(Options.IncludeMutationsOptionName)]
+    [Description(Options.IncludeMutationsOptionDescription)]
+    [DefaultValue(typeof(string), Options.IncludeMutationsOptionDefaultAttributeValue)]
+    public bool IncludeMutations { get; set; } = Options.IncludeMutationsOptionDefaultValue;
 
-    [CommandOption("--query-name")]
-    [Description("The name of the GraphQL query type")]
-    [DefaultValue(typeof(string), GraphQLToken.Query)]
-    public string? QueryName { get; set; } = GraphQLToken.Query;
+    [CommandOption(Options.BaseUrlOptionName)]
+    [Description(Options.BaseUrlOptionDescription)]
+    [DefaultValue(typeof(string), Options.BaseUrlOptionDefaultAttributeValue)]
+    public string? BaseUrl { get; set; } = Options.BaseUrlOptionDefaultValue;
 
-    [CommandOption("--mutation-name")]
-    [Description("The name of the GraphQL mutation type")]
-    [DefaultValue(typeof(string), GraphQLToken.Mutation)]
-    public string? MutationName { get; set; } = GraphQLToken.Mutation;
+    [CommandOption(Options.CustomScalarMappingOptionName)]
+    [Description(Options.CustomScalarMappingOptionDescription)]
+    [DefaultValue(typeof(string), Options.CustomScalarMappingOptionDefaultAttributeValue)]
+    public string? CustomScalarMapping { get; set; } = Options.CustomScalarMappingOptionDefaultValue;
 
-    [CommandOption("--type-filter")]
-    [Description("A comma-separated list of GraphQL types to include in the Karate feature")]
+    [CommandOption(Options.QueryOperationFilterOptionName)]
+    [Description(Options.QueryOperationFilterOptionDescription)]
     [TypeConverter(typeof(StringToSetConverter))]
-    [DefaultValue(typeof(string), "")]
-    public ISet<string> TypeFilter { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    [DefaultValue(typeof(string), Options.QueryOperationFilterOptionDefaultAttributeValue)]
+    public ISet<string> QueryOperationFilter { get; set; } = Options.QueryOperationFilterOptionDefaultValue;
 
-    [CommandOption("--query-operation-filter")]
-    [Description("A comma-separated list of GraphQL query operations to include in the Karate feature")]
+    [CommandOption(Options.MutationOperationFilterOptionName)]
+    [Description(Options.MutationOperationFilterOptionDescription)]
     [TypeConverter(typeof(StringToSetConverter))]
-    [DefaultValue(typeof(string), "")]
-    public ISet<string> QueryOperationFilter { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    [DefaultValue(typeof(string), Options.MutationOperationFilterOptionDefaultAttributeValue)]
+    public ISet<string> MutationOperationFilter { get; set; } = Options.MutationOperationFilterOptionDefaultValue;
 
-    [CommandOption("--mutation-operation-filter")]
-    [Description("A comma-separated list of GraphQL mutation operations to include in the Karate feature")]
+    [CommandOption(Options.TypeFilterOptionName)]
+    [Description(Options.TypeFilterOptionDescription)]
     [TypeConverter(typeof(StringToSetConverter))]
-    [DefaultValue(typeof(string), "")]
-    public ISet<string> MutationOperationFilter { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    [DefaultValue(typeof(string), Options.TypeFilterOptionDefaultAttributeValue)]
+    public ISet<string> TypeFilter { get; set; } = Options.TypeFilterOptionDefaultValue;
 
     public override ValidationResult Validate()
     {
@@ -95,7 +95,7 @@ internal sealed class ConvertCommandSettings : LogCommandSettings
         // ReSharper disable once ConvertIfStatementToReturnStatement - this is easier to read
         if (!_customScalarMappingValidator.IsValid(CustomScalarMapping))
         {
-            return ValidationResult.Error("The --custom-scalar-mapping option value is invalid. Please provide either a valid file path or valid custom scalar mapping value.");
+            return ValidationResult.Error($"The {Options.CustomScalarMappingOptionName} option value is invalid. Please provide either a valid file path or valid custom scalar mapping value.");
         }
 
         return ValidationResult.Success();

--- a/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/ConvertCommandSettingsLoader.cs
@@ -1,5 +1,4 @@
 ﻿using GraphQLToKarate.Library.Mappings;
-using GraphQLToKarate.Library.Tokens;
 using System.IO.Abstractions;
 
 namespace GraphQLToKarate.CommandLine.Settings;
@@ -24,13 +23,14 @@ internal sealed class ConvertCommandSettingsLoader : IConvertCommandSettingsLoad
         return new LoadedConvertCommandSettings
         {
             GraphQLSchema = graphQLSchema,
-            CustomScalarMapping = customScalarMapping,
+            InputFile = convertCommandSettings.InputFile!,
             OutputFile = convertCommandSettings.OutputFile!,
-            BaseUrl = convertCommandSettings.BaseUrl ?? "baseUrl",
+            CustomScalarMapping = customScalarMapping,
+            BaseUrl = convertCommandSettings.BaseUrl ?? Options.BaseUrlOptionDefaultValue,
             ExcludeQueries = convertCommandSettings.ExcludeQueries,
             IncludeMutations = convertCommandSettings.IncludeMutations,
-            QueryName = convertCommandSettings.QueryName ?? GraphQLToken.Query,
-            MutationName = convertCommandSettings.MutationName ?? GraphQLToken.Mutation,
+            QueryName = convertCommandSettings.QueryName ?? Options.QueryNameOptionDefaultValue,
+            MutationName = convertCommandSettings.MutationName ?? Options.MutationNameOptionDefaultValue,
             TypeFilter = convertCommandSettings.TypeFilter,
             QueryOperationFilter = convertCommandSettings.QueryOperationFilter,
             MutationOperationFilter = convertCommandSettings.MutationOperationFilter

--- a/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/LoadedConvertCommandSettings.cs
@@ -1,4 +1,5 @@
 ﻿using GraphQLToKarate.Library.Mappings;
+using System.Text;
 
 namespace GraphQLToKarate.CommandLine.Settings;
 
@@ -6,9 +7,13 @@ internal sealed class LoadedConvertCommandSettings
 {
     public required string GraphQLSchema { get; init; }
 
-    public required ICustomScalarMapping CustomScalarMapping { get; init; }
+    public required string InputFile { get; init; }
 
     public required string OutputFile { get; init; }
+
+    public required string QueryName { get; init; }
+
+    public required string MutationName { get; init; }
 
     public required bool ExcludeQueries { get; init; }
 
@@ -16,13 +21,78 @@ internal sealed class LoadedConvertCommandSettings
 
     public required string BaseUrl { get; init; }
 
-    public required string QueryName { get; init; }
-
-    public required string MutationName { get; init; }
-
-    public required ISet<string> TypeFilter { get; init; }
+    public required ICustomScalarMapping CustomScalarMapping { get; init; }
 
     public required ISet<string> QueryOperationFilter { get; init; }
 
     public required ISet<string> MutationOperationFilter { get; init; }
+
+    public required ISet<string> TypeFilter { get; init; }
+
+    public string ToCommandLineCommand()
+    {
+        var stringBuilder = new StringBuilder();
+
+        stringBuilder.Append($"graphql-to-karate convert {InputFile} --non-interactive ");
+
+        if (!string.Equals(OutputFile, Options.OutputFileOptionDefaultValue))
+        {
+            stringBuilder.Append($"{Options.OutputFileOptionName} {OutputFile} ");
+        }
+
+        if (!string.Equals(QueryName, Options.QueryNameOptionDefaultValue))
+        {
+            stringBuilder.Append($"{Options.QueryNameOptionName} {QueryName} ");
+        }
+
+        if (!string.Equals(MutationName, Options.MutationNameOptionDefaultValue))
+        {
+            stringBuilder.Append($"{Options.MutationNameOptionName} {MutationName} ");
+        }
+
+        if (ExcludeQueries)
+        {
+            stringBuilder.Append($"{Options.ExcludeQueriesOptionName} ");
+        }
+
+        if (IncludeMutations)
+        {
+            stringBuilder.Append($"{Options.IncludeMutationsOptionName} ");
+        }
+
+        if (!string.Equals(BaseUrl, Options.BaseUrlOptionDefaultValue))
+        {
+            var baseUrl = BaseUrl;
+
+            // handle escaping quotes
+            if (BaseUrl.StartsWith('\"') && BaseUrl.EndsWith('\"'))
+            {
+                baseUrl = $"\\{string.Concat(baseUrl[..^1], '\\', baseUrl[^1])}";
+            }
+
+            stringBuilder.Append($"{Options.BaseUrlOptionName} {baseUrl} ");
+        }
+
+        if (CustomScalarMapping.Any())
+        {
+            stringBuilder.Append($"{Options.CustomScalarMappingOptionName} {CustomScalarMapping.ToString()} ");
+        }
+
+        if (QueryOperationFilter.Any())
+        {
+            stringBuilder.Append($"{Options.QueryOperationFilterOptionName} {string.Join(",", QueryOperationFilter)} ");
+        }
+
+        if (MutationOperationFilter.Any())
+        {
+            stringBuilder.Append($"{Options.MutationOperationFilterOptionName} {string.Join(",", MutationOperationFilter)} ");
+        }
+
+        if (TypeFilter.Any())
+        {
+            stringBuilder.Append($"{Options.TypeFilterOptionName} {string.Join(",", TypeFilter)} ");
+        }
+
+        return stringBuilder.ToString().TrimEnd();
+    }
 }

--- a/src/GraphQLToKarate.CommandLine/Settings/Options.cs
+++ b/src/GraphQLToKarate.CommandLine/Settings/Options.cs
@@ -1,0 +1,76 @@
+﻿using GraphQLToKarate.Library.Mappings;
+using GraphQLToKarate.Library.Tokens;
+using System.Diagnostics.CodeAnalysis;
+
+namespace GraphQLToKarate.CommandLine.Settings;
+
+[SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1203:ConstantsMustAppearBeforeFields", Justification = "Readability.")]
+internal static class Options
+{
+    // --non-interactive
+    public const string NonInteractiveOptionName = "--non-interactive";
+    public const string NonInteractiveOptionDescription = "Whether to run conversion in a non-interactive way or not";
+    public const bool NonInteractiveOptionDefaultValue = false;
+    public const string NonInteractiveOptionDefaultAttributeValue = "false";
+
+    // --output file
+    public const string OutputFileOptionName = "--output-file";
+    public const string OutputFileOptionDescription = "The path of the output Karate feature file";
+    public const string OutputFileOptionDefaultValue = "graphql.feature";
+    public const string OutputFileOptionDefaultAttributeValue = "graphql.feature";
+
+    // --query-name
+    public const string QueryNameOptionName = "--query-name";
+    public const string QueryNameOptionDescription = "The name of the GraphQL query type";
+    public const string QueryNameOptionDefaultValue = GraphQLToken.Query;
+    public const string QueryNameOptionDefaultAttributeValue = GraphQLToken.Query;
+
+    // --mutation-name
+    public const string MutationNameOptionName = "--mutation-name";
+    public const string MutationNameOptionDescription = "The name of the GraphQL mutation type";
+    public const string MutationNameOptionDefaultValue = GraphQLToken.Mutation;
+    public const string MutationNameOptionDefaultAttributeValue = GraphQLToken.Mutation;
+
+    // --exclude-queries
+    public const string ExcludeQueriesOptionName = "--exclude-queries";
+    public const string ExcludeQueriesOptionDescription = "Whether to exclude queries or not";
+    public const bool ExcludeQueriesOptionDefaultValue = false;
+    public const string ExcludeQueriesOptionDefaultAttributeValue = "false";
+
+    // --include-mutations
+    public const string IncludeMutationsOptionName = "--include-mutations";
+    public const string IncludeMutationsOptionDescription = "Whether to include mutations or not";
+    public const bool IncludeMutationsOptionDefaultValue = false;
+    public const string IncludeMutationsOptionDefaultAttributeValue = "false";
+
+    // --base-url
+    public const string BaseUrlOptionName = "--base-url";
+    public const string BaseUrlOptionDescription = "The base URL to be used in the Karate feature";
+    public const string BaseUrlOptionDefaultValue = "\"https://your-awesome-api.com\"";
+    public const string BaseUrlOptionDefaultAttributeValue = "\"https://your-awesome-api.com\"";
+
+    // --custom-scalar-mapping
+    public const string CustomScalarMappingOptionName = "--custom-scalar-mapping";
+    public const string CustomScalarMappingOptionDescription = "The path or raw value custom scalar mapping";
+    public const string CustomScalarMappingOptionDefaultValue = "";
+    public const string CustomScalarMappingOptionDefaultAttributeValue = "";
+    public static readonly ICustomScalarMapping DefaultCustomScalarMapping = new CustomScalarMapping();
+
+    // --query-operation-filter
+    public const string QueryOperationFilterOptionName = "--query-operation-filter";
+    public const string QueryOperationFilterOptionDescription = "A comma-separated list of GraphQL query operations to include in the Karate feature";
+    public static readonly ISet<string> QueryOperationFilterOptionDefaultValue = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    public const string QueryOperationFilterOptionDefaultAttributeValue = "";
+
+    // --mutation-operation-filter
+    public const string MutationOperationFilterOptionName = "--mutation-operation-filter";
+    public const string MutationOperationFilterOptionDescription = "A comma-separated list of GraphQL mutation operations to include in the Karate feature";
+    public static readonly ISet<string> MutationOperationFilterOptionDefaultValue = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    public const string MutationOperationFilterOptionDefaultAttributeValue = "";
+
+    // --type-filter
+    public const string TypeFilterOptionName = "--type-filter";
+    public const string TypeFilterOptionDescription = "A comma-separated list of GraphQL types to include in the Karate feature";
+    public static readonly ISet<string> TypeFilterOptionDefaultValue = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    public const string TypeFilterOptionDefaultAttributeValue = "";
+}

--- a/src/GraphQLToKarate.Library/Mappings/CustomScalarMapping.cs
+++ b/src/GraphQLToKarate.Library/Mappings/CustomScalarMapping.cs
@@ -1,6 +1,4 @@
-﻿using System.Text;
-
-namespace GraphQLToKarate.Library.Mappings;
+﻿namespace GraphQLToKarate.Library.Mappings;
 
 /// <inheritdoc cref="ICustomScalarMapping"/>
 public sealed class CustomScalarMapping : ICustomScalarMapping

--- a/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Commands/ConvertCommandTests.cs
@@ -60,7 +60,8 @@ internal sealed class ConvertCommandTests
         var convertCommandSettings = new ConvertCommandSettings(_mockFile!, _mockCustomScalarMappingValidator!)
         {
             InputFile = "schema.graphql",
-            OutputFile = "graphql.feature"
+            OutputFile = "graphql.feature",
+            IsNonInteractive = true
         };
 
         const string schemaFileContent = "some GraphQL schema";
@@ -80,6 +81,7 @@ internal sealed class ConvertCommandTests
             .Returns(new LoadedConvertCommandSettings
             {
                 GraphQLSchema = schemaFileContent,
+                InputFile = convertCommandSettings.InputFile!,
                 OutputFile = convertCommandSettings.OutputFile!,
                 CustomScalarMapping = new CustomScalarMapping(),
                 ExcludeQueries = convertCommandSettings.ExcludeQueries,
@@ -121,7 +123,7 @@ internal sealed class ConvertCommandTests
         {
             InputFile = "schema.graphql",
             OutputFile = "graphql.feature",
-            IsInteractive = true
+            IsNonInteractive = false
         };
 
         const string schemaFileContent = "some GraphQL schema";
@@ -139,6 +141,7 @@ internal sealed class ConvertCommandTests
         var loadedConvertCommandSettings = new LoadedConvertCommandSettings
         {
             GraphQLSchema = schemaFileContent,
+            InputFile = convertCommandSettings.InputFile!,
             OutputFile = convertCommandSettings.OutputFile!,
             CustomScalarMapping = new CustomScalarMapping(),
             ExcludeQueries = convertCommandSettings.ExcludeQueries,

--- a/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Infrastructure/CommandAppConfiguratorTests.cs
@@ -74,6 +74,7 @@ internal sealed class CommandAppConfiguratorTests
         var loadedConvertCommandSettings = new LoadedConvertCommandSettings
         {
             GraphQLSchema = "some GraphQL schema",
+            InputFile = "schema.gql",
             OutputFile = "graphql.feature",
             CustomScalarMapping = new CustomScalarMapping(),
             ExcludeQueries = false,

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsTests.cs
@@ -89,7 +89,7 @@ internal sealed class ConvertCommandSettingsTests
                 "customScalarMapping.json",
                 true,
                 false,
-                "The --custom-scalar-mapping option value is invalid. Please provide either a valid file path or valid custom scalar mapping value."
+                $"The {Options.CustomScalarMappingOptionName} option value is invalid. Please provide either a valid file path or valid custom scalar mapping value."
             ).SetName("When non-null and non-empty custom scalar mapping filename points to file that doesn't exist, settings are invalid.");
 
             yield return new TestCaseData(

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/LoadedConvertCommandSettingsTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/LoadedConvertCommandSettingsTests.cs
@@ -1,0 +1,87 @@
+﻿using FluentAssertions;
+using GraphQLToKarate.CommandLine.Settings;
+using GraphQLToKarate.Library.Mappings;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.CommandLine.Tests.Settings;
+
+[TestFixture]
+internal sealed class LoadedConvertCommandSettingsTests
+{
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void ToCommandLineCommand_generates_expected_command_line_command(
+        LoadedConvertCommandSettings loadedConvertCommandSettings,
+        string expectedCommandLineOptions
+    ) => loadedConvertCommandSettings.ToCommandLineCommand().Should().Be(expectedCommandLineOptions);
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            yield return new TestCaseData(
+                new LoadedConvertCommandSettings
+                {
+                    GraphQLSchema = "some schema",
+                    InputFile = "schema.graphql",
+                    OutputFile = Options.OutputFileOptionDefaultValue,
+                    QueryName = Options.QueryNameOptionDefaultValue,
+                    MutationName = Options.MutationNameOptionDefaultValue,
+                    ExcludeQueries = Options.ExcludeQueriesOptionDefaultValue,
+                    IncludeMutations = Options.IncludeMutationsOptionDefaultValue,
+                    BaseUrl = Options.BaseUrlOptionDefaultValue,
+                    CustomScalarMapping = Options.DefaultCustomScalarMapping,
+                    QueryOperationFilter = Options.QueryOperationFilterOptionDefaultValue,
+                    MutationOperationFilter = Options.MutationOperationFilterOptionDefaultValue,
+                    TypeFilter = Options.TypeFilterOptionDefaultValue
+                },
+                "graphql-to-karate convert schema.graphql --non-interactive"
+            ).SetName("When all options are default, they are not included in the command-line option output.");
+
+            yield return new TestCaseData(
+                new LoadedConvertCommandSettings
+                {
+                    GraphQLSchema = "some schema",
+                    InputFile = "schema.graphql",
+                    OutputFile = "output.karate",
+                    QueryName = "SomeQuery",
+                    MutationName = "SomeMutation",
+                    ExcludeQueries = true,
+                    IncludeMutations = true,
+                    BaseUrl = "https://localhost:5001",
+                    CustomScalarMapping = new CustomScalarMapping(
+                        new Dictionary<string, string>
+                        {
+                            { "Date", "string" },
+                            { "Long", "number" }
+                        }
+                    ),
+                    QueryOperationFilter = new HashSet<string> { "Query1", "Query2" },
+                    MutationOperationFilter = new HashSet<string> { "Mutation1", "Mutation2" },
+                    TypeFilter = new HashSet<string> { "Type1", "Type2" }
+                },
+                "graphql-to-karate convert schema.graphql --non-interactive --output-file output.karate --query-name SomeQuery --mutation-name SomeMutation --exclude-queries --include-mutations --base-url https://localhost:5001 --custom-scalar-mapping Date:string,Long:number --query-operation-filter Query1,Query2 --mutation-operation-filter Mutation1,Mutation2 --type-filter Type1,Type2"
+            ).SetName("When all options are non-default, they are included in the command-line option output.");
+
+            // when some options are non-default and some are default, only the non-default value options are included in the output
+            yield return new TestCaseData(
+                new LoadedConvertCommandSettings
+                {
+                    GraphQLSchema = "some schema",
+                    InputFile = "schema.graphql",
+                    OutputFile = "output.karate",
+                    QueryName = Options.QueryNameOptionDefaultValue,
+                    MutationName = Options.MutationNameOptionDefaultValue,
+                    ExcludeQueries = Options.ExcludeQueriesOptionDefaultValue,
+                    IncludeMutations = true,
+                    BaseUrl = Options.BaseUrlOptionDefaultValue,
+                    CustomScalarMapping = Options.DefaultCustomScalarMapping,
+                    QueryOperationFilter = Options.QueryOperationFilterOptionDefaultValue,
+                    MutationOperationFilter = Options.MutationOperationFilterOptionDefaultValue,
+                    TypeFilter = Options.TypeFilterOptionDefaultValue
+                },
+                "graphql-to-karate convert schema.graphql --non-interactive --output-file output.karate --include-mutations"
+            ).SetName("When some options are non-default and some are default, only the non-default value options are included in the output.");
+        }
+    }
+}

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/LoadedConvertCommandSettingsTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/LoadedConvertCommandSettingsTests.cs
@@ -48,7 +48,7 @@ internal sealed class LoadedConvertCommandSettingsTests
                     MutationName = "SomeMutation",
                     ExcludeQueries = true,
                     IncludeMutations = true,
-                    BaseUrl = "https://localhost:5001",
+                    BaseUrl = "\"https://localhost:5001\"",
                     CustomScalarMapping = new CustomScalarMapping(
                         new Dictionary<string, string>
                         {
@@ -60,7 +60,7 @@ internal sealed class LoadedConvertCommandSettingsTests
                     MutationOperationFilter = new HashSet<string> { "Mutation1", "Mutation2" },
                     TypeFilter = new HashSet<string> { "Type1", "Type2" }
                 },
-                "graphql-to-karate convert schema.graphql --non-interactive --output-file output.karate --query-name SomeQuery --mutation-name SomeMutation --exclude-queries --include-mutations --base-url https://localhost:5001 --custom-scalar-mapping Date:string,Long:number --query-operation-filter Query1,Query2 --mutation-operation-filter Mutation1,Mutation2 --type-filter Type1,Type2"
+                "graphql-to-karate convert schema.graphql --non-interactive --output-file output.karate --query-name SomeQuery --mutation-name SomeMutation --exclude-queries --include-mutations --base-url \\\"https://localhost:5001\\\" --custom-scalar-mapping Date:string,Long:number --query-operation-filter Query1,Query2 --mutation-operation-filter Mutation1,Mutation2 --type-filter Type1,Type2"
             ).SetName("When all options are non-default, they are included in the command-line option output.");
 
             // when some options are non-default and some are default, only the non-default value options are included in the output


### PR DESCRIPTION
## Description

Display the non-interactive version of the command after capturing all user options:
![image](https://user-images.githubusercontent.com/45316999/225488338-bd4a4690-4dbc-47af-9a61-1f14a20e65c2.png)

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
