### PR TITLE
Support Federated Directives

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,9 @@ dotnet_diagnostic.SA1101.severity = none
 # A constructor should not follow a property
 dotnet_diagnostic.SA1201.severity = none
 
+# Static members should  not follow non-static members
+dotnet_diagnostic.SA1204.severity = none
+
 # The 'required' modifier should appear before 'public'
 dotnet_diagnostic.SA1206.severity = none
 

--- a/resources/federated.graphql
+++ b/resources/federated.graphql
@@ -1,0 +1,60 @@
+# This is a federated subgraph schema for a blogging platform
+
+# User type
+type User @key(fields: "id") {
+  id: ID! @external
+  username: String! @inaccessible(reason: "Sensitive information")
+  email: String! @inaccessible(reason: "Sensitive information")
+  role: UserRole!
+  posts: [Post!]! @requires(fields: "id")
+}
+
+# Post type
+type Post @key(fields: "id") {
+  id: ID!
+  title: String!
+  content: String!
+  author: User! @provides(fields: "username email")
+  comments: [Comment!]!
+  published: Boolean! @inaccessible(reason: "Internal field")
+}
+
+# Comment type
+type Comment @key(fields: "id") {
+  id: ID!
+  content: String!
+  author: User! @provides(fields: "username")
+  post: Post! @requires(fields: "id")
+}
+
+# UserRole enum
+enum UserRole {
+  ADMIN
+  MEMBER
+  GUEST
+}
+
+# Query type
+type Query {
+  post(id: ID!): Post
+  user(id: ID!): User @external
+}
+
+# Mutation type
+type Mutation {
+  createPost(input: PostInput!): Post!
+  createComment(input: CommentInput!): Comment!
+}
+
+# Input types
+input PostInput {
+  title: String!
+  content: String!
+  authorId: ID!
+}
+
+input CommentInput {
+  content: String!
+  authorId: ID!
+  postId: ID!
+}

--- a/src/GraphQLToKarate.Library/Apollo/Directives.cs
+++ b/src/GraphQLToKarate.Library/Apollo/Directives.cs
@@ -1,0 +1,15 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace GraphQLToKarate.Library.Apollo;
+
+/// <summary>
+///     Directives used by the Apollo Federation specification. Currently, the only ones that
+///     matter within the context of this library are <see cref="External"/> and <see cref="Inaccessible"/>,
+///     since they should be ignored when generating Karate tests.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class Directives
+{
+    public const string External = "external";
+    public const string Inaccessible = "inaccessible";
+}

--- a/src/GraphQLToKarate.Library/Extensions/GraphQLDirectiveExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/GraphQLDirectiveExtensions.cs
@@ -1,0 +1,26 @@
+﻿using GraphQLParser.AST;
+using GraphQLToKarate.Library.Apollo;
+
+namespace GraphQLToKarate.Library.Extensions;
+
+/// <summary>
+///   Extension methods for <see cref="GraphQLDirective"/>.
+/// </summary>
+internal static class GraphQLDirectiveExtensions
+{
+    /// <summary>
+    ///     Returns true if the directive is the Apollo Federation <see cref="Directives.Inaccessible"/> directive.
+    /// </summary>
+    /// <param name="graphQLDirective">The directive to check.</param>
+    /// <returns>True if the directive is the Apollo Federation <see cref="Directives.Inaccessible"/> directive.</returns>
+    public static bool IsInaccessible(this GraphQLDirective graphQLDirective) => graphQLDirective.NameValue()
+        .Equals(Directives.Inaccessible, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     Returns true if the directive is the Apollo Federation <see cref="Directives.External"/> directive.
+    /// </summary>
+    /// <param name="graphQLDirective">The directive to check.</param>
+    /// <returns>True if the directive is the Apollo Federation <see cref="Directives.External"/> directive.</returns>
+    public static bool IsExternal(this GraphQLDirective graphQLDirective) =>
+        graphQLDirective.NameValue().Equals(Directives.External, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/GraphQLToKarate.Library/Extensions/GraphQLEnumValueDefinitionExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/GraphQLEnumValueDefinitionExtensions.cs
@@ -1,0 +1,26 @@
+﻿using GraphQLParser.AST;
+using GraphQLToKarate.Library.Apollo;
+
+namespace GraphQLToKarate.Library.Extensions;
+
+/// <summary>
+///     Extension methods for <see cref="GraphQLEnumValueDefinition"/>.
+/// </summary>
+internal static class GraphQLEnumValueDefinitionExtensions
+{
+    /// <summary>
+    ///     Returns true if the enum value definition has the <see cref="Directives.Inaccessible"/> directive.
+    /// </summary>
+    /// <param name="graphQLEnumValueDefinition">The enum value definition to check.</param>
+    /// <returns>True if the enum value definition has the <see cref="Directives.Inaccessible"/> directive.</returns>
+    public static bool IsInaccessible(this GraphQLEnumValueDefinition graphQLEnumValueDefinition) =>
+        graphQLEnumValueDefinition.Directives?.Any(directive => directive.IsInaccessible()) ?? false;
+
+    /// <summary>
+    ///     Returns true if the enum value definition has the <see cref="Directives.External"/> directive.
+    /// </summary>
+    /// <param name="graphQLEnumValueDefinition">The enum value definition to check.</param>
+    /// <returns>True if the enum value definition has the <see cref="Directives.External"/> directive.</returns>
+    public static bool IsExternal(this GraphQLEnumValueDefinition graphQLEnumValueDefinition) =>
+        graphQLEnumValueDefinition.Directives?.Any(directive => directive.IsExternal()) ?? false;
+}

--- a/src/GraphQLToKarate.Library/Extensions/GraphQLFieldDefinitionExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/GraphQLFieldDefinitionExtensions.cs
@@ -1,0 +1,26 @@
+﻿using GraphQLParser.AST;
+using GraphQLToKarate.Library.Apollo;
+
+namespace GraphQLToKarate.Library.Extensions;
+
+/// <summary>
+///     Extension methods for <see cref="GraphQLFieldDefinition"/>.
+/// </summary>
+internal static class GraphQLFieldDefinitionExtensions
+{
+    /// <summary>
+    ///     Returns true if the field is the Apollo Federation <see cref="Directives.Inaccessible"/> directive.
+    /// </summary>
+    /// <param name="graphQLFieldDefinition">The field to check.</param>
+    /// <returns>True if the field is the Apollo Federation <see cref="Directives.Inaccessible"/> directive.</returns>
+    public static bool IsInaccessible(this GraphQLFieldDefinition graphQLFieldDefinition) =>
+        graphQLFieldDefinition.Directives?.Any(directive => directive.IsInaccessible()) ?? false;
+
+    /// <summary>
+    ///     Returns true if the field is the Apollo Federation <see cref="Directives.External"/> directive.
+    /// </summary>
+    /// <param name="graphQLFieldDefinition">The field to check.</param>
+    /// <returns>True if the field is the Apollo Federation <see cref="Directives.External"/> directive.</returns>
+    public static bool IsExternal(this GraphQLFieldDefinition graphQLFieldDefinition) =>
+        graphQLFieldDefinition.Directives?.Any(directive => directive.IsExternal()) ?? false;
+}

--- a/src/GraphQLToKarate.Library/Extensions/GraphQLInputValueDefinitionExtensions.cs
+++ b/src/GraphQLToKarate.Library/Extensions/GraphQLInputValueDefinitionExtensions.cs
@@ -1,0 +1,26 @@
+﻿using GraphQLParser.AST;
+using GraphQLToKarate.Library.Apollo;
+
+namespace GraphQLToKarate.Library.Extensions;
+
+/// <summary>
+///     Extension methods for <see cref="GraphQLInputValueDefinition"/>.
+/// </summary>
+internal static class GraphQLInputValueDefinitionExtensions
+{
+    /// <summary>
+    ///     Returns true if the input value definition has the <see cref="Directives.Inaccessible"/> directive.
+    /// </summary>
+    /// <param name="graphQLInputValueDefinition">The input value definition to check.</param>
+    /// <returns>True if the input value definition has the <see cref="Directives.Inaccessible"/> directive.</returns>
+    public static bool IsInaccessible(this GraphQLInputValueDefinition graphQLInputValueDefinition) =>
+        graphQLInputValueDefinition.Directives?.Any(directive => directive.IsInaccessible()) ?? false;
+
+    /// <summary>
+    ///     Returns true if the input value definition has the <see cref="Directives.External"/> directive.
+    /// </summary>
+    /// <param name="graphQLInputValueDefinition">The input value definition to check.</param>
+    /// <returns>True if the input value definition has the <see cref="Directives.External"/> directive.</returns>
+    public static bool IsExternal(this GraphQLInputValueDefinition graphQLInputValueDefinition) =>
+        graphQLInputValueDefinition.Directives?.Any(directive => directive.IsExternal()) ?? false;
+}

--- a/src/GraphQLToKarate.Library/GraphQLToKarate.Library.csproj
+++ b/src/GraphQLToKarate.Library/GraphQLToKarate.Library.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL-Parser" Version="8.1.0" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.20">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.21">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/GraphQLToKarate.Tests/Adapters/GraphQLDocumentAdapterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Adapters/GraphQLDocumentAdapterTests.cs
@@ -352,7 +352,8 @@ internal sealed class GraphQLDocumentAdapterTests
         IHasFieldsDefinitionNode? expectedResult)
     {
         // act
-        var graphQLTypeDefinitionWithFields = graphQLDocumentAdapter.GetGraphQLTypeDefinitionWithFields(graphQLTypeDefinitionName);
+        var graphQLTypeDefinitionWithFields =
+            graphQLDocumentAdapter.GetGraphQLTypeDefinitionWithFields(graphQLTypeDefinitionName);
 
         // assert
         graphQLTypeDefinitionWithFields.Should().BeEquivalentTo(expectedResult);
@@ -366,6 +367,46 @@ internal sealed class GraphQLDocumentAdapterTests
             const string graphQLInterfaceTypeDefinitionName = "interface";
             const string otherTypeDefinitionName = "other";
 
+            var mainField = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("mainField")
+            };
+
+            var inaccessibleField = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("inaccessibleField"),
+                Directives = new GraphQLDirectives
+                {
+                    Items = new List<GraphQLDirective>
+                    {
+                        new()
+                        {
+                            Name = new GraphQLName("inaccessible")
+                        }
+                    }
+                }
+            };
+
+            var externalField = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("externalField"),
+                Directives = new GraphQLDirectives
+                {
+                    Items = new List<GraphQLDirective>
+                    {
+                        new()
+                        {
+                            Name = new GraphQLName("external")
+                        }
+                    }
+                }
+            };
+
+            var extendedField = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("extendedField")
+            };
+
             var graphQLObjectTypeDefinition = new GraphQLObjectTypeDefinition
             {
                 Name = new GraphQLName(graphQLObjectTypeDefinitionName),
@@ -373,10 +414,9 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLFieldDefinition>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("mainField")
-                        }
+                        mainField,
+                        inaccessibleField,
+                        externalField
                     }
                 }
             };
@@ -388,10 +428,9 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLFieldDefinition>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("mainField")
-                        }
+                        mainField,
+                        inaccessibleField,
+                        externalField
                     }
                 }
             };
@@ -418,10 +457,9 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLFieldDefinition>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("extendedField")
-                        }
+                        extendedField,
+                        inaccessibleField,
+                        externalField
                     }
                 }
             };
@@ -433,10 +471,9 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLFieldDefinition>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("extendedField")
-                        }
+                        extendedField,
+                        inaccessibleField,
+                        externalField
                     }
                 }
             };
@@ -462,14 +499,21 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLFieldDefinition>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("mainField")
-                        },
-                        new()
-                        {
-                            Name = new GraphQLName("extendedField")
-                        }
+                        mainField,
+                        extendedField
+                    }
+                }
+            };
+
+            var expectedGraphQLInterfaceTypeDefinition = new GraphQLObjectTypeDefinition
+            {
+                Name = graphQLInterfaceTypeDefinition.Name,
+                Fields = new GraphQLFieldsDefinition
+                {
+                    Items = new List<GraphQLFieldDefinition>
+                    {
+                        mainField,
+                        extendedField
                     }
                 }
             };
@@ -485,25 +529,6 @@ internal sealed class GraphQLDocumentAdapterTests
                 graphQLObjectTypeDefinitionName,
                 expectedGraphQLObjectTypeDefinition
             ).SetName("When has fields type definition name is passed, has fields type definition is returned.");
-
-            var expectedGraphQLInterfaceTypeDefinition = new GraphQLObjectTypeDefinition
-            {
-                Name = graphQLInterfaceTypeDefinition.Name,
-                Fields = new GraphQLFieldsDefinition
-                {
-                    Items = new List<GraphQLFieldDefinition>
-                    {
-                        new()
-                        {
-                            Name = new GraphQLName("mainField")
-                        },
-                        new()
-                        {
-                            Name = new GraphQLName("extendedField")
-                        }
-                    }
-                }
-            };
 
             yield return new TestCaseData(
                 graphQLDocumentAdapter,
@@ -534,6 +559,21 @@ internal sealed class GraphQLDocumentAdapterTests
             const string unionTypeDefinitionName = "test";
             const string otherTypeDefinitionName = "other";
 
+            var mainType = new GraphQLNamedType
+            {
+                Name = new GraphQLName("mainType")
+            };
+
+            var secondType = new GraphQLNamedType
+            {
+                Name = new GraphQLName("secondType")
+            };
+
+            var thirdType = new GraphQLNamedType
+            {
+                Name = new GraphQLName("thirdType")
+            };
+
             var graphQLUnionTypeDefinition = new GraphQLUnionTypeDefinition
             {
                 Name = new GraphQLName(unionTypeDefinitionName),
@@ -541,14 +581,8 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLNamedType>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("mainType")
-                        },
-                        new()
-                        {
-                            Name = new GraphQLName("secondType")
-                        }
+                        mainType,
+                        secondType
                     }
                 }
             };
@@ -560,10 +594,7 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLNamedType>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("thirdType")
-                        }
+                        thirdType
                     }
                 }
             };
@@ -602,18 +633,9 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLNamedType>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("mainType")
-                        },
-                        new()
-                        {
-                            Name = new GraphQLName("secondType")
-                        },
-                        new()
-                        {
-                            Name = new GraphQLName("thirdType")
-                        }
+                        mainType,
+                        secondType,
+                        thirdType
                     }
                 }
             };
@@ -658,6 +680,26 @@ internal sealed class GraphQLDocumentAdapterTests
 
             const string graphQLEnumTypeDefinitionName = "Color";
 
+            var redEnumValueDefinition = new GraphQLEnumValueDefinition
+            {
+                Name = new GraphQLName("RED")
+            };
+
+            var blueEnumValueDefinition = new GraphQLEnumValueDefinition
+            {
+                Name = new GraphQLName("BLUE")
+            };
+
+            var greenEnumValueDefinition = new GraphQLEnumValueDefinition
+            {
+                Name = new GraphQLName("GREEN")
+            };
+
+            var yellowEnumValueDefinition = new GraphQLEnumValueDefinition
+            {
+                Name = new GraphQLName("YELLOW")
+            };
+
             var graphQLEnumTypeDefinition = new GraphQLEnumTypeDefinition
             {
                 Name = new GraphQLName(graphQLEnumTypeDefinitionName),
@@ -665,14 +707,8 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLEnumValueDefinition>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("RED")
-                        },
-                        new()
-                        {
-                            Name = new GraphQLName("BLUE")
-                        }
+                        redEnumValueDefinition,
+                        blueEnumValueDefinition
                     }
                 }
             };
@@ -684,14 +720,8 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLEnumValueDefinition>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("GREEN")
-                        },
-                        new()
-                        {
-                            Name = new GraphQLName("YELLOW")
-                        }
+                        greenEnumValueDefinition,
+                        yellowEnumValueDefinition
                     }
                 }
             };
@@ -727,35 +757,25 @@ internal sealed class GraphQLDocumentAdapterTests
                 }
             );
 
+            var expectedGraphQLEnumTypeDefinition = new GraphQLEnumTypeDefinition
+            {
+                Name = new GraphQLName(graphQLEnumTypeDefinitionName),
+                Values = new GraphQLEnumValuesDefinition
+                {
+                    Items = new List<GraphQLEnumValueDefinition>
+                    {
+                        redEnumValueDefinition,
+                        blueEnumValueDefinition,
+                        greenEnumValueDefinition,
+                        yellowEnumValueDefinition
+                    }
+                }
+            };
+
             yield return new TestCaseData(
                 graphQLDocumentAdapter,
                 graphQLEnumTypeDefinition.NameValue(),
-                new GraphQLEnumTypeDefinition
-                {
-                    Name = new GraphQLName(graphQLEnumTypeDefinitionName),
-                    Values = new GraphQLEnumValuesDefinition
-                    {
-                        Items = new List<GraphQLEnumValueDefinition>
-                        {
-                            new()
-                            {
-                                Name = new GraphQLName("RED")
-                            },
-                            new()
-                            {
-                                Name = new GraphQLName("BLUE")
-                            },
-                            new()
-                            {
-                                Name = new GraphQLName("GREEN")
-                            },
-                            new()
-                            {
-                                Name = new GraphQLName("YELLOW")
-                            }
-                        }
-                    }
-                }
+                expectedGraphQLEnumTypeDefinition
             ).SetName("When GraphQL document has specific enum type definition, enum type definition is found");
         }
     }
@@ -784,17 +804,26 @@ internal sealed class GraphQLDocumentAdapterTests
                 null
             ).SetName("When GraphQL document is empty, input object type definition is not found");
 
+            const string inputObjectTypeDefinitionName = "Hello";
+
+            var mainField = new GraphQLInputValueDefinition
+            {
+                Name = new GraphQLName("mainField")
+            };
+
+            var otherField = new GraphQLInputValueDefinition
+            {
+                Name = new GraphQLName("otherField")
+            };
+
             var graphQLInputObjectTypeDefinition = new GraphQLInputObjectTypeDefinition
             {
-                Name = new GraphQLName("Hello"),
+                Name = new GraphQLName(inputObjectTypeDefinitionName),
                 Fields = new GraphQLInputFieldsDefinition
                 {
                     Items = new List<GraphQLInputValueDefinition>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("mainField")
-                        }
+                        mainField
                     }
                 }
             };
@@ -806,10 +835,7 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLInputValueDefinition>
                     {
-                        new()
-                        {
-                            Name = new GraphQLName("otherField")
-                        }
+                        otherField
                     }
                 }
             };
@@ -841,6 +867,19 @@ internal sealed class GraphQLDocumentAdapterTests
                 }
             );
 
+            var expectedGraphQLInputObjectTypeDefinition = new GraphQLInputObjectTypeDefinition
+            {
+                Name = new GraphQLName(inputObjectTypeDefinitionName),
+                Fields = new GraphQLInputFieldsDefinition
+                {
+                    Items = new List<GraphQLInputValueDefinition>
+                    {
+                        mainField,
+                        otherField
+                    }
+                }
+            };
+
             yield return new TestCaseData(
                 graphQLDocumentAdapter,
                 "test",
@@ -851,25 +890,8 @@ internal sealed class GraphQLDocumentAdapterTests
 
             yield return new TestCaseData(
                 graphQLDocumentAdapter,
-                graphQLInputObjectTypeDefinition.NameValue(),
-                new GraphQLInputObjectTypeDefinition
-                {
-                    Name = new GraphQLName("Hello"),
-                    Fields = new GraphQLInputFieldsDefinition
-                    {
-                        Items = new List<GraphQLInputValueDefinition>
-                        {
-                            new()
-                            {
-                                Name = new GraphQLName("mainField")
-                            },
-                            new()
-                            {
-                                Name = new GraphQLName("otherField")
-                            }
-                        }
-                    }
-                }
+                inputObjectTypeDefinitionName,
+                expectedGraphQLInputObjectTypeDefinition
             ).SetName(
                 "When GraphQL document has specific input object type definition, input object type definition is found"
             );
@@ -890,49 +912,70 @@ internal sealed class GraphQLDocumentAdapterTests
     {
         get
         {
+            const string objectTypeDefinitionName = "SomeObjectType";
+            const string interfaceTypeDefinitionName = "SomeInterfaceType";
+            const string queryName = GraphQLToken.Query;
+
+            var graphQLObjectTypeDefinition = new GraphQLObjectTypeDefinition
+            {
+                Name = new GraphQLName(objectTypeDefinitionName),
+                Fields = new GraphQLFieldsDefinition
+                {
+                    Items = new List<GraphQLFieldDefinition>()
+                }
+            };
+
+            var graphQLInterfaceTypeDefinition = new GraphQLInterfaceTypeDefinition
+            {
+                Name = new GraphQLName(interfaceTypeDefinitionName)
+            };
+
+            var graphQLDocumentAdapter1 = new GraphQLDocumentAdapter(
+                new GraphQLDocument
+                {
+                    Definitions = new List<ASTNode>
+                    {
+                        graphQLInterfaceTypeDefinition
+                    }
+                }
+            );
+
+            var graphQLDocumentAdapter2 = new GraphQLDocumentAdapter(
+                new GraphQLDocument
+                {
+                    Definitions = new List<ASTNode>
+                    {
+                        graphQLInterfaceTypeDefinition,
+                        graphQLObjectTypeDefinition,
+                        new GraphQLObjectTypeDefinition
+                        {
+                            Name = new GraphQLName(queryName)
+                        }
+                    }
+                }
+            );
+
             yield return new TestCaseData(
                 new GraphQLDocumentAdapter(new GraphQLDocument()),
                 new List<GraphQLObjectTypeDefinition>()
             ).SetName("GraphQL document with no definitions generates expected result");
 
             yield return new TestCaseData(
-                new GraphQLDocumentAdapter(new GraphQLDocument
-                {
-                    Definitions = new List<ASTNode>
-                    {
-                        new GraphQLInterfaceTypeDefinition
-                        {
-                            Name = new GraphQLName("SomeInterfaceType")
-                        }
-                    }
-                }),
+                graphQLDocumentAdapter1,
                 new List<GraphQLObjectTypeDefinition>()
             ).SetName("GraphQL document with no object type definitions generates expected result");
 
             yield return new TestCaseData(
-                new GraphQLDocumentAdapter(new GraphQLDocument
-                {
-                    Definitions = new List<ASTNode>
-                    {
-                        new GraphQLInterfaceTypeDefinition
-                        {
-                            Name = new GraphQLName("SomeInterfaceType")
-                        },
-                        new GraphQLObjectTypeDefinition
-                        {
-                            Name = new GraphQLName("SomeObjectType")
-                        },
-                        new GraphQLObjectTypeDefinition
-                        {
-                            Name = new GraphQLName(GraphQLToken.Query)
-                        }
-                    }
-                }),
+                graphQLDocumentAdapter2,
                 new List<GraphQLObjectTypeDefinition>
                 {
                     new()
                     {
-                        Name = new GraphQLName("SomeObjectType")
+                        Name = new GraphQLName(objectTypeDefinitionName),
+                        Fields = new GraphQLFieldsDefinition
+                        {
+                            Items = new List<GraphQLFieldDefinition>()
+                        }
                     }
                 }
             ).SetName("GraphQL document with one object type definitions generates expected result");
@@ -953,49 +996,64 @@ internal sealed class GraphQLDocumentAdapterTests
     {
         get
         {
+            const string interfaceTypeName = "SomeInterfaceType";
+            const string objectTypeName = "SomeObjectType";
+            const string queryTypeName = GraphQLToken.Query;
+
+            var interfaceTypeDefinition = new GraphQLInterfaceTypeDefinition
+            {
+                Name = new GraphQLName(interfaceTypeName)
+            };
+
+            var objectTypeDefinition = new GraphQLObjectTypeDefinition
+            {
+                Name = new GraphQLName(objectTypeName)
+            };
+
+            var queryObjectTypeDefinition = new GraphQLObjectTypeDefinition
+            {
+                Name = new GraphQLName(queryTypeName)
+            };
+
+            var graphQLDocumentAdapter1 = new GraphQLDocumentAdapter(new GraphQLDocument
+            {
+                Definitions = new List<ASTNode>
+                {
+                    objectTypeDefinition
+                }
+            });
+
+            var graphQLDocumentAdapter2 = new GraphQLDocumentAdapter(new GraphQLDocument
+            {
+                Definitions = new List<ASTNode>
+                {
+                    interfaceTypeDefinition,
+                    objectTypeDefinition,
+                    queryObjectTypeDefinition
+                }
+            });
+
             yield return new TestCaseData(
                 new GraphQLDocumentAdapter(new GraphQLDocument()),
                 new List<GraphQLInterfaceTypeDefinition>()
             ).SetName("GraphQL document with no definitions generates expected result");
 
             yield return new TestCaseData(
-                new GraphQLDocumentAdapter(new GraphQLDocument
-                {
-                    Definitions = new List<ASTNode>
-                    {
-                        new GraphQLObjectTypeDefinition
-                        {
-                            Name = new GraphQLName("SomeObjectType")
-                        }
-                    }
-                }),
+                graphQLDocumentAdapter1,
                 new List<GraphQLInterfaceTypeDefinition>()
             ).SetName("GraphQL document with no interface type definitions generates expected result");
 
             yield return new TestCaseData(
-                new GraphQLDocumentAdapter(new GraphQLDocument
-                {
-                    Definitions = new List<ASTNode>
-                    {
-                        new GraphQLInterfaceTypeDefinition
-                        {
-                            Name = new GraphQLName("SomeInterfaceType")
-                        },
-                        new GraphQLObjectTypeDefinition
-                        {
-                            Name = new GraphQLName("SomeObjectType")
-                        },
-                        new GraphQLObjectTypeDefinition
-                        {
-                            Name = new GraphQLName(GraphQLToken.Query)
-                        }
-                    }
-                }),
+                graphQLDocumentAdapter2,
                 new List<GraphQLInterfaceTypeDefinition>
                 {
                     new()
                     {
-                        Name = new GraphQLName("SomeInterfaceType")
+                        Name = new GraphQLName(interfaceTypeName),
+                        Fields = new GraphQLFieldsDefinition
+                        {
+                            Items = new List<GraphQLFieldDefinition>()
+                        }
                     }
                 }
             ).SetName("GraphQL document with one interface type definition generates expected result");
@@ -1048,7 +1106,11 @@ internal sealed class GraphQLDocumentAdapterTests
                 }),
                 new GraphQLObjectTypeDefinition
                 {
-                    Name = new GraphQLName(GraphQLToken.Query)
+                    Name = new GraphQLName(GraphQLToken.Query),
+                    Fields = new GraphQLFieldsDefinition
+                    {
+                        Items = new List<GraphQLFieldDefinition>()
+                    }
                 }
             ).SetName("GraphQL document with query definition returns expected result.");
         }
@@ -1100,7 +1162,11 @@ internal sealed class GraphQLDocumentAdapterTests
                 }),
                 new GraphQLObjectTypeDefinition
                 {
-                    Name = new GraphQLName(GraphQLToken.Mutation)
+                    Name = new GraphQLName(GraphQLToken.Mutation),
+                    Fields = new GraphQLFieldsDefinition
+                    {
+                        Items = new List<GraphQLFieldDefinition>()
+                    }
                 }
             ).SetName("GraphQL document with mutation definition returns expected result.");
         }

--- a/tests/GraphQLToKarate.Tests/Adapters/GraphQLDocumentAdapterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Adapters/GraphQLDocumentAdapterTests.cs
@@ -816,6 +816,36 @@ internal sealed class GraphQLDocumentAdapterTests
                 Name = new GraphQLName("otherField")
             };
 
+            var inaccessibleField = new GraphQLInputValueDefinition
+            {
+                Name = new GraphQLName("inaccessibleField"),
+                Directives = new GraphQLDirectives
+                {
+                    Items = new List<GraphQLDirective>
+                    {
+                        new()
+                        {
+                            Name = new GraphQLName("inaccessible")
+                        }
+                    }
+                }
+            };
+
+            var externalField = new GraphQLInputValueDefinition
+            {
+                Name = new GraphQLName("externalField"),
+                Directives = new GraphQLDirectives
+                {
+                    Items = new List<GraphQLDirective>
+                    {
+                        new()
+                        {
+                            Name = new GraphQLName("external")
+                        }
+                    }
+                }
+            };
+
             var graphQLInputObjectTypeDefinition = new GraphQLInputObjectTypeDefinition
             {
                 Name = new GraphQLName(inputObjectTypeDefinitionName),
@@ -823,7 +853,8 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLInputValueDefinition>
                     {
-                        mainField
+                        mainField,
+                        inaccessibleField
                     }
                 }
             };
@@ -835,7 +866,8 @@ internal sealed class GraphQLDocumentAdapterTests
                 {
                     Items = new List<GraphQLInputValueDefinition>
                     {
-                        otherField
+                        otherField,
+                        externalField
                     }
                 }
             };

--- a/tests/GraphQLToKarate.Tests/Extensions/GraphQLDirectiveExtensionsTests.cs
+++ b/tests/GraphQLToKarate.Tests/Extensions/GraphQLDirectiveExtensionsTests.cs
@@ -1,0 +1,35 @@
+﻿using FluentAssertions;
+using GraphQLParser.AST;
+using GraphQLToKarate.Library.Apollo;
+using GraphQLToKarate.Library.Extensions;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.Tests.Extensions;
+
+[TestFixture]
+internal sealed class GraphQLDirectiveExtensionsTests
+{
+    [TestCase(Directives.Inaccessible, true)]
+    [TestCase(Directives.External, false)]
+    [TestCase("otherDirective", false)]
+    public void IsInaccessible_returns_expected_result(string directiveName, bool expectedResult)
+    {
+        var directive = new GraphQLDirective { Name = new GraphQLName(directiveName) };
+
+        var result = directive.IsInaccessible();
+
+        result.Should().Be(expectedResult);
+    }
+
+    [TestCase(Directives.Inaccessible, false)]
+    [TestCase(Directives.External, true)]
+    [TestCase("otherDirective", false)]
+    public void IsExternal_returns_expected_result(string directiveName, bool expectedResult)
+    {
+        var directive = new GraphQLDirective { Name = new GraphQLName(directiveName) };
+
+        var result = directive.IsExternal();
+
+        result.Should().Be(expectedResult);
+    }
+}

--- a/tests/GraphQLToKarate.Tests/Extensions/GraphQLEnumValueDefinitionExtensionsTests.cs
+++ b/tests/GraphQLToKarate.Tests/Extensions/GraphQLEnumValueDefinitionExtensionsTests.cs
@@ -1,0 +1,99 @@
+﻿using FluentAssertions;
+using GraphQLParser.AST;
+using GraphQLToKarate.Library.Apollo;
+using GraphQLToKarate.Library.Extensions;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.Tests.Extensions;
+
+[TestFixture]
+public class GraphQLEnumValueDefinitionExtensionsTests
+{
+    [Test]
+    [TestCase(Directives.Inaccessible, true)]
+    [TestCase(Directives.External, false)]
+    [TestCase("someDirective", false)]
+    public void IsInaccessible_returns_expected_result(string directiveName, bool expected)
+    {
+        // arrange
+        var graphQLEnumValueDefinition = new GraphQLEnumValueDefinition
+        {
+            Directives = new GraphQLDirectives
+            {
+                Items = new List<GraphQLDirective>
+                {
+                    new()
+                    {
+                        Name = new GraphQLName(directiveName)
+                    }
+                }
+            }
+        };
+
+        // act
+        var result = graphQLEnumValueDefinition.IsInaccessible();
+
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Test]
+    [TestCase(Directives.Inaccessible, false)]
+    [TestCase(Directives.External, true)]
+    [TestCase("someDirective", false)]
+    public void IsExternal_returns_expected_result(string directiveName, bool expected)
+    {
+        // arrange
+        var graphQLEnumValueDefinition = new GraphQLEnumValueDefinition
+        {
+            Directives = new GraphQLDirectives
+            {
+                Items = new List<GraphQLDirective>
+                {
+                    new()
+                    {
+                        Name = new GraphQLName(directiveName)
+                    }
+                }
+            }
+        };
+
+        // act
+        var result = graphQLEnumValueDefinition.IsExternal();
+
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Test]
+    public void IsInaccessible_returns_false_for_null_directives()
+    {
+        // arrange
+        var graphQLEnumValueDefinition = new GraphQLEnumValueDefinition
+        {
+            Directives = null
+        };
+
+        // act
+        var result = graphQLEnumValueDefinition.IsInaccessible();
+
+        // assert
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public void IsExternal_returns_false_for_null_directives()
+    {
+        // arrange
+        var graphQLEnumValueDefinition = new GraphQLEnumValueDefinition
+        {
+            Directives = null
+        };
+
+        // act
+        var result = graphQLEnumValueDefinition.IsExternal();
+
+        // assert
+        result.Should().BeFalse();
+    }
+}

--- a/tests/GraphQLToKarate.Tests/Extensions/GraphQLFieldDefinitionExtensionsTests.cs
+++ b/tests/GraphQLToKarate.Tests/Extensions/GraphQLFieldDefinitionExtensionsTests.cs
@@ -1,0 +1,93 @@
+﻿using FluentAssertions;
+using GraphQLParser.AST;
+using GraphQLToKarate.Library.Apollo;
+using GraphQLToKarate.Library.Extensions;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.Tests.Extensions;
+
+[TestFixture]
+public class GraphQLFieldDefinitionExtensionsTests
+{
+    [Test]
+    [TestCase(Directives.Inaccessible, true)]
+    [TestCase(Directives.External, false)]
+    [TestCase("someDirective", false)]
+    public void IsInaccessible_returns_expected_result(string directiveName, bool expected)
+    {
+        // arrange
+        var fieldDefinition = new GraphQLFieldDefinition
+        {
+            Directives = new GraphQLDirectives
+            {
+                Items = new List<GraphQLDirective>
+                {
+                    new()
+                    {
+                        Name = new GraphQLName(directiveName)
+                    }
+                }
+            }
+        };
+
+        // act
+        var result = fieldDefinition.IsInaccessible();
+
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Test]
+    [TestCase(Directives.External, true)]
+    [TestCase(Directives.Inaccessible, false)]
+    [TestCase("someDirective", false)]
+    public void IsExternal_returns_expected_result(string directiveName, bool expected)
+    {
+        // arrange
+        var fieldDefinition = new GraphQLFieldDefinition
+        {
+            Directives = new GraphQLDirectives
+            {
+                Items = new List<GraphQLDirective>
+                {
+                    new()
+                    {
+                        Name = new GraphQLName(directiveName)
+                    }
+                }
+            }
+        };
+
+        // act
+        var result = fieldDefinition.IsExternal();
+
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Test]
+    public void IsInaccessible_with_null_directives_returns_false()
+    {
+        // arrange
+        var fieldDefinition = new GraphQLFieldDefinition();
+
+        // act
+        var result = fieldDefinition.IsInaccessible();
+
+        // assert
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public void IsExternal_with_null_directives_returns_false()
+    {
+        // arrange
+        var fieldDefinition = new GraphQLFieldDefinition();
+
+        // act
+        var result = fieldDefinition.IsExternal();
+
+        // assert
+        result.Should().BeFalse();
+    }
+}

--- a/tests/GraphQLToKarate.Tests/Extensions/GraphQLInputValueDefinitionExtensionsTests.cs
+++ b/tests/GraphQLToKarate.Tests/Extensions/GraphQLInputValueDefinitionExtensionsTests.cs
@@ -1,0 +1,93 @@
+﻿using FluentAssertions;
+using GraphQLParser.AST;
+using GraphQLToKarate.Library.Apollo;
+using GraphQLToKarate.Library.Extensions;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.Tests.Extensions;
+
+[TestFixture]
+public class GraphQLInputValueDefinitionExtensionsTests
+{
+    [Test]
+    public void IsInaccessible_returns_false_when_directives_is_null()
+    {
+        // arrange
+        var inputValueDefinition = new GraphQLInputValueDefinition();
+
+        // act
+        var result = inputValueDefinition.IsInaccessible();
+
+        // assert
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    [TestCase(Directives.Inaccessible, true)]
+    [TestCase(Directives.External, false)]
+    [TestCase("someDirective", false)]
+    public void IsInaccessible_returns_expected_result(string directiveName, bool expected)
+    {
+        // arrange
+        var inputValueDefinition = new GraphQLInputValueDefinition
+        {
+            Directives = new GraphQLDirectives
+            {
+                Items = new List<GraphQLDirective>
+                {
+                    new()
+                    {
+                        Name = new GraphQLName(directiveName)
+                    }
+                }
+            }
+        };
+
+        // act
+        var result = inputValueDefinition.IsInaccessible();
+
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Test]
+    public void IsExternal_returns_false_when_directives_is_null()
+    {
+        // arrange
+        var inputValueDefinition = new GraphQLInputValueDefinition();
+
+        // act
+        var result = inputValueDefinition.IsExternal();
+
+        // assert
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    [TestCase(Directives.Inaccessible, false)]
+    [TestCase(Directives.External, true)]
+    [TestCase("someDirective", false)]
+    public void IsExternal_returns_expected_result(string directiveName, bool expected)
+    {
+        // arrange
+        var inputValueDefinition = new GraphQLInputValueDefinition
+        {
+            Directives = new GraphQLDirectives
+            {
+                Items = new List<GraphQLDirective>
+                {
+                    new()
+                    {
+                        Name = new GraphQLName(directiveName)
+                    }
+                }
+            }
+        };
+
+        // act
+        var result = inputValueDefinition.IsExternal();
+
+        // assert
+        result.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Description

Starts addressing https://github.com/wbaldoumas/graphql-to-karate/issues/73 in a simple way, by excluding `@inaccessible` and `@external` fields on GraphQL `object`, `interface`, and `input` types. Also removes `@inaccessible` and `@external` GraphQL `enum` values.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
