### PR TITLE
Handle More Return Types

### DIFF
--- a/resources/configuration.json
+++ b/resources/configuration.json
@@ -1,12 +1,4 @@
 {
     "outputFile": "configured-contries.feature",
-    "baseUrl": "\"https://countries.trevorblades.com\"",
-    "customScalarMapping": {
-        "Date": "string",
-        "DateTime": "string",
-        "Long": "number"
-    },
-    "queryOperationFilter": [
-        "countries"
-    ]
+    "baseUrl": "\"https://countries.trevorblades.com\""
 }

--- a/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
@@ -109,36 +109,39 @@ public sealed class GraphQLToKarateConverterBuilder :
         return this;
     }
 
-    public IGraphQLToKarateConverter Build() => new GraphQLToKarateConverter(
-        new GraphQLSchemaParser(),
-        new GraphQLTypeDefinitionConverter(
-            new GraphQLTypeConverterFactory(_graphQLTypeConverter)
-        ),
-        new GraphQLFieldDefinitionConverter(
-            new GraphQLInputValueDefinitionConverterFactory(
-                new GraphQLInputValueToExampleValueConverter(
-                    new GraphQLScalarToExampleValueConverter(_customScalarMapping)
+    public IGraphQLToKarateConverter Build()
+    {
+        var graphQLTypeConverterFactory = new GraphQLTypeConverterFactory(_graphQLTypeConverter);
+
+        return new GraphQLToKarateConverter(
+            new GraphQLSchemaParser(),
+            new GraphQLTypeDefinitionConverter(graphQLTypeConverterFactory),
+            new GraphQLFieldDefinitionConverter(
+                new GraphQLInputValueDefinitionConverterFactory(
+                    new GraphQLInputValueToExampleValueConverter(
+                        new GraphQLScalarToExampleValueConverter(_customScalarMapping)
+                    )
                 )
-            )
-        ),
-        new KarateFeatureBuilder(
-            new KarateScenarioBuilder(),
-            new KarateFeatureBuilderSettings
+            ),
+            new KarateFeatureBuilder(
+                new KarateScenarioBuilder(graphQLTypeConverterFactory),
+                new KarateFeatureBuilderSettings
+                {
+                    BaseUrl = _baseUrl,
+                    ExcludeQueries = _excludeQueriesSetting
+                }
+            ),
+            _graphQLToKarateConverterLogger,
+            new GraphQLToKarateSettings
             {
-                BaseUrl = _baseUrl,
-                ExcludeQueries = _excludeQueriesSetting
+                ExcludeQueries = _excludeQueriesSetting,
+                IncludeMutations = _includeMutationsSetting,
+                QueryName = _queryName,
+                MutationName = _mutationName,
+                TypeFilter = _typeFilter,
+                QueryOperationFilter = _queryOperationFilter,
+                MutationOperationFilter = _mutationOperationFilter
             }
-        ),
-        _graphQLToKarateConverterLogger,
-        new GraphQLToKarateSettings
-        {
-            ExcludeQueries = _excludeQueriesSetting,
-            IncludeMutations = _includeMutationsSetting,
-            QueryName = _queryName,
-            MutationName = _mutationName,
-            TypeFilter = _typeFilter,
-            QueryOperationFilter = _queryOperationFilter,
-            MutationOperationFilter = _mutationOperationFilter
-        }
-    );
+        );
+    }
 }

--- a/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverterFactory.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLTypeConverterFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace GraphQLToKarate.Library.Converters;
+﻿using GraphQLParser.AST;
+
+namespace GraphQLToKarate.Library.Converters;
 
 /// <inheritdoc cref="IGraphQLTypeConverterFactory"/>
 public sealed class GraphQLTypeConverterFactory : IGraphQLTypeConverterFactory
@@ -20,4 +22,10 @@ public sealed class GraphQLTypeConverterFactory : IGraphQLTypeConverterFactory
     public IGraphQLTypeConverter CreateGraphQLNonNullTypeConverter() => _graphQLNonNullTypeConverter ??= new GraphQLNonNullTypeConverter(this);
 
     public IGraphQLTypeConverter CreateGraphQLNullTypeConverter() => _graphQLNullTypeConverter ??= new GraphQLNullTypeConverter(this);
+
+    public IGraphQLTypeConverter CreateGraphQLTypeConverter(GraphQLType graphQLType) => graphQLType switch
+    {
+        GraphQLNonNullType => CreateGraphQLNonNullTypeConverter(),
+        _ => CreateGraphQLNullTypeConverter()
+    };
 }

--- a/src/GraphQLToKarate.Library/Converters/GraphQLTypeDefinitionConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLTypeDefinitionConverter.cs
@@ -1,6 +1,5 @@
 ﻿using GraphQLParser.AST;
 using GraphQLToKarate.Library.Adapters;
-using GraphQLToKarate.Library.Exceptions;
 using GraphQLToKarate.Library.Extensions;
 using GraphQLToKarate.Library.Types;
 
@@ -26,13 +25,7 @@ public sealed class GraphQLTypeDefinitionConverter : IGraphQLTypeDefinitionConve
 
         var karateTypes =
             from graphQLFieldDefinition in graphQLTypeDefinition.Fields
-            let converter = graphQLFieldDefinition.Type switch
-            {
-                GraphQLNonNullType => _graphQLTypeConverterFactory.CreateGraphQLNonNullTypeConverter(),
-                GraphQLNamedType => _graphQLTypeConverterFactory.CreateGraphQLNullTypeConverter(),
-                GraphQLListType => _graphQLTypeConverterFactory.CreateGraphQLNullTypeConverter(),
-                _ => throw new InvalidGraphQLTypeException()
-            }
+            let converter = _graphQLTypeConverterFactory.CreateGraphQLTypeConverter(graphQLFieldDefinition.Type)
             select converter.Convert(
                 graphQLFieldDefinition.NameValue(),
                 graphQLFieldDefinition.Type,

--- a/src/GraphQLToKarate.Library/Converters/IGraphQLTypeConverterFactory.cs
+++ b/src/GraphQLToKarate.Library/Converters/IGraphQLTypeConverterFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace GraphQLToKarate.Library.Converters;
+﻿using GraphQLParser.AST;
+
+namespace GraphQLToKarate.Library.Converters;
 
 /// <summary>
 ///     Used to create various <see cref="IGraphQLTypeConverter"/> implementations.
@@ -12,4 +14,6 @@ public interface IGraphQLTypeConverterFactory
     IGraphQLTypeConverter CreateGraphQLNonNullTypeConverter();
 
     IGraphQLTypeConverter CreateGraphQLNullTypeConverter();
+
+    IGraphQLTypeConverter CreateGraphQLTypeConverter(GraphQLType graphQLType);
 }

--- a/src/GraphQLToKarate.Library/Types/GraphQLOperation.cs
+++ b/src/GraphQLToKarate.Library/Types/GraphQLOperation.cs
@@ -12,9 +12,9 @@ public sealed class GraphQLOperation
 
     public string OperationName => $"{Name.FirstCharToUpper()}Test";
 
-    public string ReturnTypeName => _graphQLFieldDefinition.Type.GetUnwrappedTypeName();
+    public GraphQLType ReturnType => _graphQLFieldDefinition.Type;
 
-    public bool IsNullableReturnType => _graphQLFieldDefinition.Type is not GraphQLNonNullType;
+    public string ReturnTypeName => _graphQLFieldDefinition.Type.GetUnwrappedTypeName();
 
     public bool IsListReturnType => _graphQLFieldDefinition.Type.IsListType();
 

--- a/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
+++ b/tests/GraphQLToKarate.CommandLine.Tests/Settings/ConvertCommandSettingsLoaderTests.cs
@@ -220,7 +220,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
         var convertCommandSettings = new ConvertCommandSettings(_mockFile!, _mockCustomScalarMappingLoader!)
         {
             InputFile = "schema.graphql",
-            ConfigurationFile = "config.json",
+            ConfigurationFile = "config.json"
         };
 
         _mockFile!
@@ -328,7 +328,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
         var convertCommandSettings = new ConvertCommandSettings(_mockFile!, _mockCustomScalarMappingLoader!)
         {
             InputFile = "schema.graphql",
-            ConfigurationFile = "config.json",
+            ConfigurationFile = "config.json"
         };
 
         _mockFile!
@@ -357,7 +357,7 @@ internal sealed class ConvertCommandSettingsLoaderTests
         var convertCommandSettings = new ConvertCommandSettings(_mockFile!, _mockCustomScalarMappingLoader!)
         {
             InputFile = "schema.graphql",
-            ConfigurationFile = "config.json",
+            ConfigurationFile = "config.json"
         };
 
         _mockFile!

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLTypeConverterFactoryTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLTypeConverterFactoryTests.cs
@@ -1,0 +1,44 @@
+﻿using FluentAssertions;
+using GraphQLParser.AST;
+using GraphQLToKarate.Library.Converters;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.Tests.Converters;
+
+[TestFixture]
+internal sealed class GraphQLTypeConverterFactoryTests
+{
+    private GraphQLTypeConverterFactory? _subjectUnderTest;
+
+    [SetUp]
+    public void SetUp() => _subjectUnderTest = new GraphQLTypeConverterFactory(new GraphQLTypeConverter());
+
+    [Test]
+    [TestCaseSource(nameof(TypeConverterTestCases))]
+    public void CreateGraphQLTypeConverter_Returns_Expected_Type_Instance(
+        GraphQLType graphQLType,
+        Type expectedType)
+    {
+        // act
+        var typeConverter = _subjectUnderTest!.CreateGraphQLTypeConverter(graphQLType);
+
+        // assert
+        typeConverter.Should().BeOfType(expectedType);
+    }
+
+    private static IEnumerable<TestCaseData> TypeConverterTestCases
+    {
+        get
+        {
+            yield return new TestCaseData(
+                new GraphQLNonNullType(),
+                typeof(GraphQLNonNullTypeConverter)
+            ).SetName("Returns GraphQLNonNullTypeConverter for GraphQLNonNullType input");
+
+            yield return new TestCaseData(
+                new GraphQLNamedType(),
+                typeof(GraphQLNullTypeConverter)
+            ).SetName("Returns GraphQLNullTypeConverter for other GraphQLType input");
+        }
+    }
+}

--- a/tests/GraphQLToKarate.Tests/Features/KarateScenarioBuilderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Features/KarateScenarioBuilderTests.cs
@@ -456,7 +456,7 @@ internal sealed class KarateScenarioBuilderTests
                   Then status 200
                   And match each response.data.todoUnion == "#? isValid(_)"
                 """"
-            ).SetName("Simple query with union return type is validated as expected.");
+            ).SetName("Simple query with list union return type is validated as expected.");
 
             var graphQLFieldDefinitionWithScalarReturnType = new GraphQLFieldDefinition
             {

--- a/tests/GraphQLToKarate.Tests/Features/KarateScenarioBuilderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Features/KarateScenarioBuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using GraphQLParser.AST;
 using GraphQLToKarate.Library.Adapters;
+using GraphQLToKarate.Library.Converters;
 using GraphQLToKarate.Library.Enums;
 using GraphQLToKarate.Library.Features;
 using GraphQLToKarate.Library.Tokens;
@@ -19,7 +20,7 @@ internal sealed class KarateScenarioBuilderTests
     [SetUp]
     public void SetUp()
     {
-        _subjectUnderTest = new KarateScenarioBuilder();
+        _subjectUnderTest = new KarateScenarioBuilder(new GraphQLTypeConverterFactory(new GraphQLTypeConverter()));
         _mockGraphQLDocumentAdapter = Substitute.For<IGraphQLDocumentAdapter>();
     }
 
@@ -28,6 +29,7 @@ internal sealed class KarateScenarioBuilderTests
     public void ScenarioBuilder_builds_expected_scenario_string(
         GraphQLOperation graphQLOperation,
         GraphQLUnionTypeDefinition? graphQLUnionTypeDefinitionReturn,
+        bool isGraphQLTypeDefinitionWithFields,
         string expectedScenarioString)
     {
         // arrange
@@ -39,6 +41,13 @@ internal sealed class KarateScenarioBuilderTests
         {
             _mockGraphQLDocumentAdapter!
                 .IsGraphQLUnionTypeDefinition(Arg.Any<string>())
+                .Returns(true);
+        }
+
+        if (isGraphQLTypeDefinitionWithFields)
+        {
+            _mockGraphQLDocumentAdapter!
+                .IsGraphQLTypeDefinitionWithFields(Arg.Any<string>())
                 .Returns(true);
         }
 
@@ -78,6 +87,7 @@ internal sealed class KarateScenarioBuilderTests
                     """
                 },
                 null,
+                true,
                 """"
                 Scenario: Perform a todo query and validate the response
                   * text query =
@@ -145,6 +155,7 @@ internal sealed class KarateScenarioBuilderTests
                     """
                 },
                 null,
+                true,
                 """"
                 Scenario: Perform a todo query and validate the response
                   * text query =
@@ -160,12 +171,12 @@ internal sealed class KarateScenarioBuilderTests
                       }
                     """
 
-                  * text variables =
+                  * def variables =
                     """
                       {
-                        "id": "an example value",
-                        "isCompleted": true,
-                        "filter": [ RED, BLUE ]
+                        id: "an example value",
+                        isCompleted: true,
+                        filter: [ RED, BLUE ]
                       }
                     """
 
@@ -205,6 +216,7 @@ internal sealed class KarateScenarioBuilderTests
                     """
                 },
                 null,
+                true,
                 """"
                 Scenario: Perform a todo query and validate the response
                   * text query =
@@ -221,7 +233,7 @@ internal sealed class KarateScenarioBuilderTests
                   And request { query: '#(query)', operationName: "TodoTest" }
                   When method post
                   Then status 200
-                  And match each response.data.todo == "##(todoSchema)"
+                  And match response.data.todo == "##[] ##(todoSchema)"
                 """"
             ).SetName("Simple query without arguments and list return is generated as a valid scenario.");
 
@@ -256,6 +268,7 @@ internal sealed class KarateScenarioBuilderTests
                     """
                 },
                 null,
+                true,
                 """"
                 Scenario: Perform a todo query and validate the response
                   * text query =
@@ -272,7 +285,7 @@ internal sealed class KarateScenarioBuilderTests
                   And request { query: '#(query)', operationName: "TodoTest" }
                   When method post
                   Then status 200
-                  And match each response.data.todo == todoSchema
+                  And match response.data.todo == "#[] ##(todoSchema)"
                 """"
             ).SetName("Simple query without arguments and non-null list return is generated as a valid scenario.");
 
@@ -281,12 +294,9 @@ internal sealed class KarateScenarioBuilderTests
                 Name = new GraphQLName("todoUnion"),
                 Type = new GraphQLNonNullType
                 {
-                    Type = new GraphQLListType
+                    Type = new GraphQLNamedType
                     {
-                        Type = new GraphQLNamedType
-                        {
-                            Name = new GraphQLName("TodoUnion")
-                        }
+                        Name = new GraphQLName("TodoUnion")
                     }
                 }
             };
@@ -329,6 +339,93 @@ internal sealed class KarateScenarioBuilderTests
                         }
                     }
                 },
+                false,
+                """"
+                Scenario: Perform a todoUnion query and validate the response
+                  * text query =
+                    """
+                      query TodoUnionTest {
+                        todoUnion {
+                          ... on Todo {
+                            id
+                            name
+                          }
+                          ... on TodoError {
+                            message
+                          }
+                        }
+                      }
+                    """
+
+                  * def isValid =
+                    """
+                    response =>
+                      karate.match(response, todoSchema).pass ||
+                      karate.match(response, todoErrorSchema).pass
+                    """
+
+                  Given path "/graphql"
+                  And request { query: '#(query)', operationName: "TodoUnionTest" }
+                  When method post
+                  Then status 200
+                  And match response.data.todoUnion == "#? isValid(_)"
+                """"
+            ).SetName("Simple query with union return type is validated as expected.");
+
+            var graphQLFieldDefinitionWithListUnionReturnType = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("todoUnion"),
+                Type = new GraphQLNonNullType
+                {
+                    Type = new GraphQLListType
+                    {
+                        Type = new GraphQLNamedType
+                        {
+                            Name = new GraphQLName("TodoUnion")
+                        }
+                    }
+                }
+            };
+
+            yield return new TestCaseData(
+                new GraphQLOperation(graphQLFieldDefinitionWithListUnionReturnType)
+                {
+                    Type = GraphQLOperationType.Query,
+                    Arguments = new List<GraphQLArgumentTypeBase>(),
+                    OperationString =
+                    """
+                    query TodoUnionTest {
+                      todoUnion {
+                        ... on Todo {
+                          id
+                          name
+                        }
+                        ... on TodoError {
+                          message
+                        }
+                      }
+                    }
+                    """
+                },
+                new GraphQLUnionTypeDefinition
+                {
+                    Name = new GraphQLName("TodoUnion"),
+                    Types = new GraphQLUnionMemberTypes
+                    {
+                        Items = new List<GraphQLNamedType>
+                        {
+                            new()
+                            {
+                                Name = new GraphQLName("Todo")
+                            },
+                            new()
+                            {
+                                Name = new GraphQLName("TodoError")
+                            }
+                        }
+                    }
+                },
+                false,
                 """"
                 Scenario: Perform a todoUnion query and validate the response
                   * text query =
@@ -360,6 +457,46 @@ internal sealed class KarateScenarioBuilderTests
                   And match each response.data.todoUnion == "#? isValid(_)"
                 """"
             ).SetName("Simple query with union return type is validated as expected.");
+
+            var graphQLFieldDefinitionWithScalarReturnType = new GraphQLFieldDefinition
+            {
+                Name = new GraphQLName("todoCount"),
+                Type = new GraphQLNamedType
+                {
+                    Name = new GraphQLName("Int")
+                }
+            };
+
+            yield return new TestCaseData(
+                new GraphQLOperation(graphQLFieldDefinitionWithScalarReturnType)
+                {
+                    Type = GraphQLOperationType.Query,
+                    Arguments = new List<GraphQLArgumentTypeBase>(),
+                    OperationString =
+                    """
+                    query TodoCountTest {
+                      todoCount
+                    }
+                    """
+                },
+                null,
+                false,
+                """"
+                Scenario: Perform a todoCount query and validate the response
+                  * text query =
+                    """
+                      query TodoCountTest {
+                        todoCount
+                      }
+                    """
+
+                  Given path "/graphql"
+                  And request { query: '#(query)', operationName: "TodoCountTest" }
+                  When method post
+                  Then status 200
+                  And match response.data.todoCount == "##number"
+                """"
+            ).SetName("Simple query with scalar return type is generated as a valid scenario.");
         }
     }
 }


### PR DESCRIPTION
## Description

- Refactor `KarateScenarioBuilder` to leverage `IGraphQLTypeConverter` instances for more flexible return type validation.
- Adjust variables in Karate scenarios (use `def` instead of `text`)
- Additional cleanup

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
