### PR TITLE
Cyclic to Acyclic Converter

### DIFF
--- a/resources/blog.graphql
+++ b/resources/blog.graphql
@@ -1,64 +1,57 @@
-# Custom scalar types
 scalar DateTime
 
-# Enumerations
+type Query {
+  userById(id: ID!): User!
+  blogPostById(id: ID!): BlogPost!
+  commentById(id: ID!): Comment!
+  users(pageInfo: PageInfoInput): UserConnection!
+  blogPosts(pageInfo: PageInfoInput): BlogPostConnection!
+  comments(pageInfo: PageInfoInput): CommentConnection!
+  search(query: String!): [SearchResult!]!
+}
+
+type Mutation {
+  createUser(input: CreateUserInput!): User!
+  updateUser(input: UpdateUserInput!): User!
+  deleteUser(id: ID!): Boolean!
+}
+
 enum UserRole {
   GUEST
   STANDARD
   ADMINISTRATOR
 }
 
-# Interface
 interface Node {
   id: ID!
 }
 
-# Union type
-union SearchResult = User | BlogPost | Comment
-
-# Input types
-input CreateUserInput {
-  name: String!
-  password: String!
-  role: UserRole
-}
-
-input UpdateUserInput {
-  id: ID!
-  name: String
-  role: UserRole
-}
-
-input PageInfoInput {
-  limit: Int
-  offset: Int
-}
-
-# Object types
 type User implements Node {
-  id: ID!
   name: String!
   role: UserRole!
+  blogPosts: [BlogPost!]!
   createdAt: DateTime!
   updatedAt: DateTime!
+  id: ID!
 }
 
 type BlogPost implements Node {
-  id: ID!
   title: String!
   content: String!
   author: User!
+  comments: [Comment!]!
   createdAt: DateTime!
   updatedAt: DateTime!
+  id: ID!
 }
 
 type Comment implements Node {
-  id: ID!
   content: String!
   author: User!
   blogPost: BlogPost!
   createdAt: DateTime!
   updatedAt: DateTime!
+  id: ID!
 }
 
 type PageInfo {
@@ -82,25 +75,21 @@ type CommentConnection {
   pageInfo: PageInfo!
 }
 
-# Root types
-type Query {
-  user(id: ID!): User
-  blogPost(id: ID!): BlogPost
-  comment(id: ID!): Comment
-  users(pageInfo: PageInfoInput): UserConnection!
-  blogPosts(pageInfo: PageInfoInput): BlogPostConnection!
-  comments(pageInfo: PageInfoInput): CommentConnection!
-  search(query: String!): [SearchResult!]!
+input UpdateUserInput {
+  id: String!
+  name: String!
+  role: UserRole!
 }
 
-type Mutation {
-  createUser(input: CreateUserInput!): User!
-  updateUser(input: UpdateUserInput!): User!
-  deleteUser(id: ID!): Boolean!
-  # Add more mutations for blog posts and comments
+input CreateUserInput {
+  name: String!
+  password: String!
+  role: UserRole!
 }
 
-schema {
-  query: Query
-  mutation: Mutation
+union SearchResult = User | BlogPost | Comment
+
+input PageInfoInput {
+  limit: Int
+  offset: Int
 }

--- a/resources/countries.graphql
+++ b/resources/countries.graphql
@@ -1,67 +1,40 @@
-""""""
 type Query {
-  """"""
   continents: [Continent]
-  """"""
   continent(code: ID!): Continent
-  """"""
   countries: [Country]
-  """"""
   country(code: ID!): Country
-  """"""
   languages: [Language]
-  """"""
   language(code: ID!): Language
 }
 
-""""""
 type Continent {
-  """"""
   code: ID
-  """"""
   name: String
-  """"""
   countries: [Country]
 }
 
-""""""
 type Country {
-  """"""
   code: ID
-  """"""
   name: String
-  """"""
   native: String
-  """"""
   phone: String
-  """"""
+  continent: Continent
   currency: String
-  """"""
   languages: [Language]
-  """"""
   emoji: String
-  """"""
   emojiU: String
-  """"""
   states: [State]
 }
 
-""""""
 type Language {
-  """"""
   code: ID
-  """"""
   name: String
-  """"""
   native: String
-  """"""
   rtl: Boolean
 }
 
-""""""
 type State {
-  """"""
   code: ID
-  """"""
   name: String
+  country: Country
 }

--- a/src/GraphQLToKarate.CommandLine/GraphQLToKarate.CommandLine.csproj
+++ b/src/GraphQLToKarate.CommandLine/GraphQLToKarate.CommandLine.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.33">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/GraphQLToKarate.CommandLine/Infrastructure/HostConfigurator.cs
+++ b/src/GraphQLToKarate.CommandLine/Infrastructure/HostConfigurator.cs
@@ -2,6 +2,7 @@
 using GraphQLToKarate.CommandLine.Prompts;
 using GraphQLToKarate.CommandLine.Settings;
 using GraphQLToKarate.Library.Builders;
+using GraphQLToKarate.Library.Converters;
 using GraphQLToKarate.Library.Mappings;
 using GraphQLToKarate.Library.Parsers;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,6 +36,7 @@ internal static class HostConfigurator
             serviceCollection.AddSingleton<ICustomScalarMappingValidator, CustomScalarMappingLoader>();
             serviceCollection.AddSingleton<ICustomScalarMappingLoader, CustomScalarMappingLoader>();
             serviceCollection.AddSingleton<IGraphQLSchemaParser, GraphQLSchemaParser>();
+            serviceCollection.AddSingleton<IGraphQLCyclicToAcyclicConverter, GraphQLCyclicToAcyclicConverter>();
             serviceCollection.AddSingleton<IConvertCommandSettingsPrompt, ConvertCommandSettingsPrompt>();
         })
         .UseSerilog((_, loggerConfiguration) =>

--- a/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
+++ b/src/GraphQLToKarate.Library/Builders/GraphQLToKarateConverterBuilder.cs
@@ -15,6 +15,8 @@ public sealed class GraphQLToKarateConverterBuilder :
 {
     private readonly ILogger<GraphQLToKarateConverter> _graphQLToKarateConverterLogger;
 
+    private readonly IGraphQLCyclicToAcyclicConverter _graphQLCyclicToAcyclicConverter;
+
     private IGraphQLTypeConverter _graphQLTypeConverter = new GraphQLTypeConverter();
 
     private bool _excludeQueriesSetting;
@@ -35,10 +37,15 @@ public sealed class GraphQLToKarateConverterBuilder :
 
     private ICustomScalarMapping _customScalarMapping = new CustomScalarMapping();
 
-    public GraphQLToKarateConverterBuilder(ILogger<GraphQLToKarateConverter> graphQLToKarateConverterLogger) => _graphQLToKarateConverterLogger = graphQLToKarateConverterLogger;
+    public GraphQLToKarateConverterBuilder(ILogger<GraphQLToKarateConverter> graphQLToKarateConverterLogger, IGraphQLCyclicToAcyclicConverter graphQLCyclicToAcyclicConverter)
+    {
+        _graphQLToKarateConverterLogger = graphQLToKarateConverterLogger;
+        _graphQLCyclicToAcyclicConverter = graphQLCyclicToAcyclicConverter;
+    }
 
     public IConfigurableGraphQLToKarateConverterBuilder Configure() => new GraphQLToKarateConverterBuilder(
-        _graphQLToKarateConverterLogger
+        _graphQLToKarateConverterLogger,
+        _graphQLCyclicToAcyclicConverter
     );
 
     public IConfigurableGraphQLToKarateConverterBuilder WithCustomScalarMapping(
@@ -131,6 +138,7 @@ public sealed class GraphQLToKarateConverterBuilder :
                     ExcludeQueries = _excludeQueriesSetting
                 }
             ),
+            _graphQLCyclicToAcyclicConverter,
             _graphQLToKarateConverterLogger,
             new GraphQLToKarateSettings
             {

--- a/src/GraphQLToKarate.Library/Converters/GraphQLCyclicToAcyclicConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLCyclicToAcyclicConverter.cs
@@ -1,0 +1,121 @@
+﻿using GraphQLParser.AST;
+using GraphQLToKarate.Library.Adapters;
+using GraphQLToKarate.Library.Extensions;
+using QuikGraph;
+
+namespace GraphQLToKarate.Library.Converters;
+
+/// <inheritdoc cref="IGraphQLCyclicToAcyclicConverter"/>
+internal sealed class GraphQLCyclicToAcyclicConverter : IGraphQLCyclicToAcyclicConverter
+{
+    public void Convert(
+        GraphQLFieldDefinition graphQLFieldDefinition,
+        IGraphQLDocumentAdapter graphQLDocumentAdapter)
+    {
+        var fieldRelationshipsGraph = new AdjacencyGraph<string, Edge<string>>();
+        var unwrappedTypeName = graphQLFieldDefinition.Type.GetUnwrappedTypeName();
+
+        if (graphQLDocumentAdapter.IsGraphQLUnionTypeDefinition(unwrappedTypeName))
+        {
+            Convert(
+                graphQLDocumentAdapter.GetGraphQLUnionTypeDefinition(unwrappedTypeName)!,
+                graphQLDocumentAdapter,
+                fieldRelationshipsGraph
+            );
+        }
+        else if (graphQLDocumentAdapter.IsGraphQLTypeDefinitionWithFields(unwrappedTypeName))
+        {
+            Convert(
+                graphQLDocumentAdapter.GetGraphQLTypeDefinitionWithFields(unwrappedTypeName),
+                unwrappedTypeName,
+                graphQLDocumentAdapter,
+                fieldRelationshipsGraph
+            );
+        }
+    }
+
+    private static void Convert(
+        GraphQLUnionTypeDefinition graphQLUnionTypeDefinition,
+        IGraphQLDocumentAdapter graphQLDocumentAdapter,
+        AdjacencyGraph<string, Edge<string>> fieldRelationshipsGraph)
+    {
+        foreach (var graphQLUnionMemberType in graphQLUnionTypeDefinition.Types!)
+        {
+            var unwrappedTypeName = graphQLUnionMemberType.GetUnwrappedTypeName();
+
+            Convert(
+                graphQLDocumentAdapter.GetGraphQLTypeDefinitionWithFields(unwrappedTypeName),
+                unwrappedTypeName,
+                graphQLDocumentAdapter,
+                fieldRelationshipsGraph
+            );
+        }
+    }
+
+    private static void Convert(
+        IHasFieldsDefinitionNode? graphQLTypeDefinitionWithFields,
+        string unwrappedTypeName,
+        IGraphQLDocumentAdapter graphQLDocumentAdapter,
+        AdjacencyGraph<string, Edge<string>> fieldRelationshipsGraph)
+    {
+        if (graphQLTypeDefinitionWithFields is null || !(graphQLTypeDefinitionWithFields.Fields?.Any() ?? false))
+        {
+            return;
+        }
+
+        fieldRelationshipsGraph.AddVertex(unwrappedTypeName);
+
+        var typesCausingCycles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var childFieldDefinition in graphQLTypeDefinitionWithFields.Fields)
+        {
+            var unwrappedChildTypeName = childFieldDefinition.Type.GetUnwrappedTypeName();
+
+            if (graphQLDocumentAdapter.IsGraphQLUnionTypeDefinition(unwrappedChildTypeName))
+            {
+                Convert(
+                    graphQLDocumentAdapter.GetGraphQLUnionTypeDefinition(unwrappedChildTypeName)!,
+                    graphQLDocumentAdapter,
+                    fieldRelationshipsGraph
+                );
+
+                continue;
+            }
+
+            fieldRelationshipsGraph.AddVertex(unwrappedChildTypeName);
+
+            var edge = new Edge<string>(unwrappedTypeName, unwrappedChildTypeName);
+
+            fieldRelationshipsGraph.AddEdge(edge);
+
+            if (fieldRelationshipsGraph.IsCyclic())
+            {
+                typesCausingCycles.Add(unwrappedChildTypeName);
+                fieldRelationshipsGraph.RemoveEdge(edge);
+
+                continue;
+            }
+
+            var childGraphQLTypeDefinitionWithFields = graphQLDocumentAdapter.GetGraphQLTypeDefinitionWithFields(
+                unwrappedChildTypeName
+            );
+
+            if (childGraphQLTypeDefinitionWithFields is null ||
+                !(childGraphQLTypeDefinitionWithFields.Fields?.Any() ?? false))
+            {
+                continue;
+            }
+
+            Convert(
+                childGraphQLTypeDefinitionWithFields,
+                unwrappedChildTypeName,
+                graphQLDocumentAdapter,
+                fieldRelationshipsGraph
+            );
+        }
+
+        graphQLTypeDefinitionWithFields.Fields.Items = graphQLTypeDefinitionWithFields.Fields
+            .Where(fieldDefinition => !typesCausingCycles.Contains(fieldDefinition.Type.GetUnwrappedTypeName()))
+            .ToList();
+    }
+}

--- a/src/GraphQLToKarate.Library/Converters/GraphQLCyclicToAcyclicConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/GraphQLCyclicToAcyclicConverter.cs
@@ -6,7 +6,7 @@ using QuikGraph;
 namespace GraphQLToKarate.Library.Converters;
 
 /// <inheritdoc cref="IGraphQLCyclicToAcyclicConverter"/>
-internal sealed class GraphQLCyclicToAcyclicConverter : IGraphQLCyclicToAcyclicConverter
+public sealed class GraphQLCyclicToAcyclicConverter : IGraphQLCyclicToAcyclicConverter
 {
     public void Convert(
         GraphQLFieldDefinition graphQLFieldDefinition,

--- a/src/GraphQLToKarate.Library/Converters/IGraphQLCyclicToAcyclicConverter.cs
+++ b/src/GraphQLToKarate.Library/Converters/IGraphQLCyclicToAcyclicConverter.cs
@@ -1,0 +1,20 @@
+﻿using GraphQLParser.AST;
+using GraphQLToKarate.Library.Adapters;
+
+namespace GraphQLToKarate.Library.Converters;
+
+/// <summary>
+///     Removes cycles from GraphQL field definitions.
+/// </summary>
+public interface IGraphQLCyclicToAcyclicConverter
+{
+    /// <summary>
+    ///    Removes cycles from the given <see cref="GraphQLFieldDefinition"/>.
+    /// </summary>
+    /// <param name="graphQLFieldDefinition">The field definition to remove cycles from.</param>
+    /// <param name="graphQLDocumentAdapter">The GraphQL document adapter, providing access to user-defined types within the GraphQL document.</param>
+    void Convert(
+        GraphQLFieldDefinition graphQLFieldDefinition,
+        IGraphQLDocumentAdapter graphQLDocumentAdapter
+    );
+}

--- a/src/GraphQLToKarate.Library/GraphQLToKarate.Library.csproj
+++ b/src/GraphQLToKarate.Library/GraphQLToKarate.Library.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL-Parser" Version="8.1.0" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.33">
+    <PackageReference Include="GraphQL-Parser" Version="8.2.0" />
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="QuikGraph" Version="2.5.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="19.2.11" />
+    <PackageReference Include="System.IO.Abstractions" Version="19.2.16" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/GraphQLToKarate.Integration.Api/GraphQLToKarate.Integration.Api.csproj
+++ b/tests/GraphQLToKarate.Integration.Api/GraphQLToKarate.Integration.Api.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
    <PackageReference Include="HotChocolate.AspNetCore" Version="13.0.5" />
-   <PackageReference Include="Meziantou.Analyzer" Version="2.0.33">
+   <PackageReference Include="Meziantou.Analyzer" Version="2.0.34">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
    </PackageReference>

--- a/tests/GraphQLToKarate.Integration.Api/Types/BlogPost.cs
+++ b/tests/GraphQLToKarate.Integration.Api/Types/BlogPost.cs
@@ -8,6 +8,8 @@ public sealed class BlogPost : Node, ISearchResult
 
     public required User Author { get; init; }
 
+    public required IEnumerable<Comment> Comments { get; init; }
+
     public required DateTime CreatedAt { get; init; }
 
     public required DateTime UpdatedAt { get; init; }

--- a/tests/GraphQLToKarate.Integration.Api/Types/Mutation.cs
+++ b/tests/GraphQLToKarate.Integration.Api/Types/Mutation.cs
@@ -7,6 +7,7 @@ public sealed class Mutation
         Id = Guid.NewGuid().ToString(),
         Name = input.Name,
         Role = input.Role,
+        BlogPosts = new List<BlogPost>(),
         CreatedAt = DateTime.UtcNow,
         UpdatedAt = DateTime.UtcNow,
     };
@@ -16,6 +17,7 @@ public sealed class Mutation
         Id = input.Id,
         Name = input.Name,
         Role = input.Role,
+        BlogPosts = new List<BlogPost>(),
         CreatedAt = DateTime.UtcNow,
         UpdatedAt = DateTime.UtcNow,
     };

--- a/tests/GraphQLToKarate.Integration.Api/Types/Query.cs
+++ b/tests/GraphQLToKarate.Integration.Api/Types/Query.cs
@@ -7,6 +7,63 @@ public sealed class Query
         Id = id,
         Name = "John Doe",
         Role = UserRole.Administrator,
+        BlogPosts = new List<BlogPost>
+        {
+            new()
+            {
+                Id = Guid.NewGuid().ToString(),
+                Title = "GraphQL to Karate",
+                Content = "GraphQL to Karate is a tool that converts GraphQL schemas to Karate tests.",
+                Author = new User
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Name = "John Doe",
+                    Role = UserRole.Administrator,
+                    BlogPosts = new List<BlogPost>(),
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                },
+                Comments = new List<Comment>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        Content = "GraphQL to Karate is a tool that converts GraphQL schemas to Karate tests.",
+                        Author = new User
+                        {
+                            Id = Guid.NewGuid().ToString(),
+                            Name = "John Doe",
+                            Role = UserRole.Administrator,
+                            BlogPosts = new List<BlogPost>(),
+                            CreatedAt = DateTime.UtcNow,
+                            UpdatedAt = DateTime.UtcNow
+                        },
+                        BlogPost = new BlogPost
+                        {
+                            Id = Guid.NewGuid().ToString(),
+                            Title = "GraphQL to Karate",
+                            Content = "GraphQL to Karate is a tool that converts GraphQL schemas to Karate tests.",
+                            Author = new User
+                            {
+                                Id = Guid.NewGuid().ToString(),
+                                Name = "John Doe",
+                                Role = UserRole.Administrator,
+                                BlogPosts = new List<BlogPost>(),
+                                CreatedAt = DateTime.UtcNow,
+                                UpdatedAt = DateTime.UtcNow
+                            },
+                            Comments = new List<Comment>(),
+                            CreatedAt = DateTime.UtcNow,
+                            UpdatedAt = DateTime.UtcNow
+                        },
+                        CreatedAt = DateTime.UtcNow,
+                        UpdatedAt = DateTime.UtcNow
+                    }
+                },
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        },
         CreatedAt = DateTime.UtcNow,
         UpdatedAt = DateTime.UtcNow
     };
@@ -17,6 +74,43 @@ public sealed class Query
         Title = "GraphQL to Karate",
         Content = "GraphQL to Karate is a tool that converts GraphQL schemas to Karate tests.",
         Author = GetUserById(Guid.NewGuid().ToString()),
+        Comments = new List<Comment>
+        {
+            new()
+            {
+                Id = Guid.NewGuid().ToString(),
+                Content = "GraphQL to Karate is a tool that converts GraphQL schemas to Karate tests.",
+                Author = new User
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Name = "John Doe",
+                    Role = UserRole.Administrator,
+                    BlogPosts = new List<BlogPost>(),
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                },
+                BlogPost = new BlogPost
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Title = "GraphQL to Karate",
+                    Content = "GraphQL to Karate is a tool that converts GraphQL schemas to Karate tests.",
+                    Author = new User
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        Name = "John Doe",
+                        Role = UserRole.Administrator,
+                        BlogPosts = new List<BlogPost>(),
+                        CreatedAt = DateTime.UtcNow,
+                        UpdatedAt = DateTime.UtcNow
+                    },
+                    Comments = new List<Comment>(),
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                },
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }
+        },
         CreatedAt = DateTime.UtcNow,
         UpdatedAt = DateTime.UtcNow
     };

--- a/tests/GraphQLToKarate.Integration.Api/Types/User.cs
+++ b/tests/GraphQLToKarate.Integration.Api/Types/User.cs
@@ -6,6 +6,8 @@ public sealed class User : Node, ISearchResult
 
     public required UserRole Role { get; init; }
 
+    public required IEnumerable<BlogPost> BlogPosts { get; init; }
+
     public required DateTime CreatedAt { get; init; }
 
     public required DateTime UpdatedAt { get; init; }

--- a/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
+++ b/tests/GraphQLToKarate.Tests/Builders/GraphQLToKarateConverterBuilderTests.cs
@@ -12,9 +12,14 @@ namespace GraphQLToKarate.Tests.Builders;
 internal sealed class GraphQLToKarateConverterBuilderTests
 {
     private ILogger<GraphQLToKarateConverter>? _mockLogger;
+    private IGraphQLCyclicToAcyclicConverter? _mockGraphQLCyclicToAcyclicConverter;
 
     [SetUp]
-    public void SetUp() => _mockLogger = Substitute.For<ILogger<GraphQLToKarateConverter>>();
+    public void SetUp()
+    {
+        _mockLogger = Substitute.For<ILogger<GraphQLToKarateConverter>>();
+        _mockGraphQLCyclicToAcyclicConverter = Substitute.For<IGraphQLCyclicToAcyclicConverter>();
+    }
 
     [Test]
     [TestCase(true)]
@@ -28,7 +33,7 @@ internal sealed class GraphQLToKarateConverterBuilderTests
                 : new Dictionary<string, string>()
         );
 
-        var subjectUnderTest = new GraphQLToKarateConverterBuilder(_mockLogger!);
+        var subjectUnderTest = new GraphQLToKarateConverterBuilder(_mockLogger!, _mockGraphQLCyclicToAcyclicConverter!);
 
         // act
         var graphQLToKarateConverter = subjectUnderTest

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLCyclicToAcyclicConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLCyclicToAcyclicConverterTests.cs
@@ -1,0 +1,228 @@
+﻿using FluentAssertions;
+using GraphQLParser;
+using GraphQLParser.AST;
+using GraphQLToKarate.Library.Adapters;
+using GraphQLToKarate.Library.Converters;
+using GraphQLToKarate.Library.Extensions;
+using NUnit.Framework;
+
+namespace GraphQLToKarate.Tests.Converters;
+
+[TestFixture]
+internal sealed class GraphQLCyclicToAcyclicConverterTests
+{
+    private IGraphQLCyclicToAcyclicConverter? _subjectUnderTest;
+
+    [SetUp]
+    public void SetUp() => _subjectUnderTest = new GraphQLCyclicToAcyclicConverter();
+
+    private const string GraphQLSchema =
+        """
+        schema {
+          query: Query
+        }
+
+        type Query {
+          user(id: ID!): User
+          post(id: ID!): Post
+          comment(id: ID!): Comment
+          category(id: ID!): Category
+        }
+
+        type User {
+          id: ID!
+          name: String!
+          posts: [Post!]!
+          friend: User # Direct cycle: User => User
+        }
+
+        type Post {
+          id: ID!
+          title: String!
+          content: String!
+          author: User! # Transitive cycle: Post => User => Post
+          comments: [Comment!]!
+          category: Category
+        }
+
+        type Comment {
+          id: ID!
+          content: String!
+          author: User! # Transitive cycle: Comment => User => Post => Comment
+          post: Post! # Transitive cycle: Comment => Post => Comment
+        }
+
+        # No cycles
+        type Category {
+          id: ID!
+          name: String!
+          description: String             
+        }
+        """;
+
+    private const string GraphQLSchemaWithUnionTypes =
+        """
+        schema {
+          query: Query
+        }
+
+        union Entity = User | Post | Comment | Category
+
+        type Query {
+          entity(id: ID!, entityType: EntityType!): Entity
+        }
+
+        enum EntityType {
+          USER
+          POST
+          COMMENT
+          CATEGORY
+        }
+
+        type User {
+          id: ID!
+          name: String!
+          posts: [Post!]!
+          friend: User # Direct cycle: User => User
+        }
+
+        type Post {
+          id: ID!
+          title: String!
+          content: String!
+          author: User! # Transitive cycle: Post => User => Post
+          comments: [Comment!]!
+          category: Category
+        }
+
+        type Comment {
+          id: ID!
+          content: String!
+          author: User! # Transitive cycle: Comment => User => Post => Comment
+          post: Post! # Transitive cycle: Comment => Post => Comment
+        }
+
+        # No cycles
+        type Category {
+          id: ID!
+          name: String!
+          description: String             
+        }
+        """;
+
+    private const string GraphQLSchemaWithNestedUnionTypes =
+        """
+        schema {
+          query: Query
+        }
+
+        union Entity = User | Post | Comment | Category
+
+        type Query {        
+          nestedEntity(id: ID!): NestedEntity
+        }
+
+        enum EntityType {
+          USER
+          POST
+          COMMENT
+          CATEGORY
+        }
+
+        type User {
+          id: ID!
+          name: String!
+          posts: [Post!]!
+          friend: User # Direct cycle: User => User
+        }
+
+        type Post {
+          id: ID!
+          title: String!
+          content: String!
+          author: User! # Transitive cycle: Post => User => Post
+          comments: [Comment!]!
+          category: Category
+        }
+
+        type Comment {
+          id: ID!
+          content: String!
+          author: User! # Transitive cycle: Comment => User => Post => Comment
+          post: Post! # Transitive cycle: Comment => Post => Comment
+        }
+
+        # No cycles
+        type Category {
+          id: ID!
+          name: String!
+          description: String             
+        }
+
+        type NestedEntity {
+          id: ID!
+          entity: Entity
+          relatedEntity: NestedEntity # Direct cycle: NestedEntity => NestedEntity
+        }
+        """;
+
+    [Test]
+    [TestCase(GraphQLSchema)]
+    [TestCase(GraphQLSchemaWithUnionTypes)]
+    [TestCase(GraphQLSchemaWithNestedUnionTypes)]
+    public void Convert_removes_cycles_in_cyclical_field_definition_types(string graphQLSchema)
+    {
+        // arrange
+        var graphQLDocumentAdapter = new GraphQLDocumentAdapter(Parser.Parse(graphQLSchema));
+
+        // act
+        foreach (var graphQLFieldDefinition in graphQLDocumentAdapter.GraphQLQueryTypeDefinition!.Fields!)
+        {
+            _subjectUnderTest!.Convert(graphQLFieldDefinition, graphQLDocumentAdapter);
+        }
+
+        // assert
+        var user = graphQLDocumentAdapter.GetGraphQLTypeDefinitionWithFields("User");
+
+        AssertContainsField(user!, "id");
+        AssertContainsField(user!, "name");
+        AssertContainsField(user!, "posts");
+        AssertDoesNotContainField(user!, "friend");
+
+        var post = graphQLDocumentAdapter.GetGraphQLTypeDefinitionWithFields("Post");
+
+        AssertContainsField(post!, "id");
+        AssertContainsField(post!, "title");
+        AssertContainsField(post!, "content");
+        AssertContainsField(post!, "comments");
+        AssertContainsField(post!, "category");
+        AssertDoesNotContainField(post!, "author");
+
+        var comment = graphQLDocumentAdapter.GetGraphQLTypeDefinitionWithFields("Comment");
+
+        AssertContainsField(comment!, "id");
+        AssertContainsField(comment!, "content");
+        AssertDoesNotContainField(comment!, "author");
+        AssertDoesNotContainField(comment!, "post");
+
+        var category = graphQLDocumentAdapter.GetGraphQLTypeDefinitionWithFields("Category");
+
+        AssertContainsField(category!, "id");
+        AssertContainsField(category!, "name");
+        AssertContainsField(category!, "description");
+    }
+
+    private static void AssertContainsField(IHasFieldsDefinitionNode hasFieldsDefinitionNode, string fieldName) =>
+        hasFieldsDefinitionNode.Fields!.Items
+            .Should()
+            .Contain(graphQLFieldDefinition =>
+                graphQLFieldDefinition.NameValue().Equals(fieldName, StringComparison.OrdinalIgnoreCase)
+            );
+
+    private static void AssertDoesNotContainField(IHasFieldsDefinitionNode hasFieldsDefinitionNode, string fieldName) =>
+        hasFieldsDefinitionNode.Fields!.Items
+            .Should()
+            .NotContain(graphQLFieldDefinition =>
+                graphQLFieldDefinition.NameValue().Equals(fieldName, StringComparison.OrdinalIgnoreCase)
+            );
+}

--- a/tests/GraphQLToKarate.Tests/Converters/GraphQLToKarateConverterTests.cs
+++ b/tests/GraphQLToKarate.Tests/Converters/GraphQLToKarateConverterTests.cs
@@ -23,6 +23,7 @@ internal sealed class GraphQLToKarateConverterTests
     private IGraphQLTypeDefinitionConverter? _mockGraphQLTypeDefinitionConverter;
     private IGraphQLFieldDefinitionConverter? _mockGraphQLFieldDefinitionConverter;
     private IKarateFeatureBuilder? _mockKarateFeatureBuilder;
+    private IGraphQLCyclicToAcyclicConverter? _mockGraphQLCyclicToAcyclicConverter;
     private ILogger<GraphQLToKarateConverter>? _mockLogger;
 
     [SetUp]
@@ -32,6 +33,7 @@ internal sealed class GraphQLToKarateConverterTests
         _mockGraphQLTypeDefinitionConverter = Substitute.For<IGraphQLTypeDefinitionConverter>();
         _mockGraphQLFieldDefinitionConverter = Substitute.For<IGraphQLFieldDefinitionConverter>();
         _mockKarateFeatureBuilder = Substitute.For<IKarateFeatureBuilder>();
+        _mockGraphQLCyclicToAcyclicConverter = Substitute.For<IGraphQLCyclicToAcyclicConverter>();
         _mockLogger = Substitute.For<ILogger<GraphQLToKarateConverter>>();
     }
 
@@ -92,6 +94,7 @@ internal sealed class GraphQLToKarateConverterTests
             _mockGraphQLTypeDefinitionConverter,
             _mockGraphQLFieldDefinitionConverter,
             _mockKarateFeatureBuilder,
+            _mockGraphQLCyclicToAcyclicConverter!,
             _mockLogger!,
             settings
         );
@@ -193,6 +196,7 @@ internal sealed class GraphQLToKarateConverterTests
             _mockGraphQLTypeDefinitionConverter,
             _mockGraphQLFieldDefinitionConverter,
             _mockKarateFeatureBuilder,
+            _mockGraphQLCyclicToAcyclicConverter!,
             _mockLogger!,
             settings
         );
@@ -296,6 +300,7 @@ internal sealed class GraphQLToKarateConverterTests
             _mockGraphQLTypeDefinitionConverter,
             _mockGraphQLFieldDefinitionConverter,
             _mockKarateFeatureBuilder,
+            _mockGraphQLCyclicToAcyclicConverter!,
             _mockLogger!,
             settings
         );
@@ -391,6 +396,7 @@ internal sealed class GraphQLToKarateConverterTests
             _mockGraphQLTypeDefinitionConverter,
             _mockGraphQLFieldDefinitionConverter,
             _mockKarateFeatureBuilder,
+            _mockGraphQLCyclicToAcyclicConverter!,
             _mockLogger!,
             settings
         );
@@ -481,6 +487,7 @@ internal sealed class GraphQLToKarateConverterTests
             _mockGraphQLTypeDefinitionConverter,
             _mockGraphQLFieldDefinitionConverter,
             _mockKarateFeatureBuilder,
+            _mockGraphQLCyclicToAcyclicConverter!,
             _mockLogger!,
             settings
         );
@@ -571,6 +578,7 @@ internal sealed class GraphQLToKarateConverterTests
             _mockGraphQLTypeDefinitionConverter,
             _mockGraphQLFieldDefinitionConverter,
             _mockKarateFeatureBuilder,
+            _mockGraphQLCyclicToAcyclicConverter!,
             _mockLogger!,
             settings
         );
@@ -646,6 +654,7 @@ internal sealed class GraphQLToKarateConverterTests
             _mockGraphQLTypeDefinitionConverter,
             _mockGraphQLFieldDefinitionConverter!,
             _mockKarateFeatureBuilder,
+            _mockGraphQLCyclicToAcyclicConverter!,
             _mockLogger!,
             settings
         );


### PR DESCRIPTION
## Description

A converter which can convert cyclic GraphQL types to their acyclic equivalents by removing fields that cause cycles.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
