### PR TITLE
Swap to VERSION env var in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ steps.extract_version.outputs.version }}
-          release_name: Release v${{ steps.extract_version.outputs.version }}
+              tag_name: v${{ env.VERSION }}
+              release_name: Release v${{ env.VERSION }}
           draft: false
           prerelease: false
 
@@ -89,7 +89,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./publish/linux-x64.zip
-          asset_name: graphql-to-karate-${{ steps.extract_version.outputs.version }}-linux-x64.zip
+          asset_name: graphql-to-karate-${{ env.VERSION }}-linux-x64.zip
           asset_content_type: application/zip
 
       - name: 🔼 upload windows artifacts
@@ -100,7 +100,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./publish/win-x64.zip
-          asset_name: graphql-to-karate-${{ steps.extract_version.outputs.version }}-win-x64.zip
+          asset_name: graphql-to-karate-${{ env.VERSION }}-win-x64.zip
           asset_content_type: application/zip
 
       - name: 🔼 upload macos artifacts
@@ -111,5 +111,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./publish/osx-x64.zip
-          asset_name: graphql-to-karate-${{ steps.extract_version.outputs.version }}-osx-x64.zip
+          asset_name: graphql-to-karate-${{ env.VERSION }}-osx-x64.zip
           asset_content_type: application/zip          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-              tag_name: v${{ env.VERSION }}
-              release_name: Release v${{ env.VERSION }}
+          tag_name: v${{ env.VERSION }}
+          release_name: Release v${{ env.VERSION }}
           draft: false
           prerelease: false
 


### PR DESCRIPTION
## Description

Swap to `VERSION` environment variable from outputs for versioning.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/graphql-to-karate/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
